### PR TITLE
Add Chainstack

### DIFF
--- a/data/ecosystems/c/chainstack.toml
+++ b/data/ecosystems/c/chainstack.toml
@@ -1,0 +1,43 @@
+# Ecosystem Level Information
+title = "Chainstack"
+
+sub_ecosystems = []
+
+github_organizations = ["https://github.com/chainstack"]
+
+# Repositories
+[[repo]]
+url = "https://github.com/chainstack/docs"
+
+[[repo]]
+url = "https://github.com/chainstack/ethereum-certificates-tutorial"
+
+[[repo]]
+url = "https://github.com/chainstack/quorum-docker"
+
+[[repo]]
+url = "https://github.com/chainstack/multichain-explorer-docker"
+
+[[repo]]
+url = "https://github.com/chainstack/multichain-explorer"
+
+[[repo]]
+url = "https://github.com/chainstack/corda-shell-docker"
+
+[[repo]]
+url = "https://github.com/chainstack/corda-docker"
+
+[[repo]]
+url = "https://github.com/chainstack/quorum-iot-tutorial"
+
+[[repo]]
+url = "https://github.com/chainstack/quorum-loyalty-program-tutorial"
+
+[[repo]]
+url = "https://github.com/chainstack/quorum-explorer"
+
+[[repo]]
+url = "https://github.com/chainstack/multichain-docker"
+
+[[repo]]
+url = "https://github.com/chainstack/multichaincli"


### PR DESCRIPTION
Add Chainstack -- a blockchain deployment platform similar to Infura
but with multi-protocol support