### PR TITLE
Remove copied repos

### DIFF
--- a/data/ecosystems/b/bitcoin-cash.toml
+++ b/data/ecosystems/b/bitcoin-cash.toml
@@ -107,12 +107,6 @@ url = "https://github.com/dsmurrell/awesome-bitcoin-cash"
 url = "https://github.com/Ekliptor/cashp"
 
 [[repo]]
-url = "https://github.com/Electron-Cash/android-platform-ndk"
-
-[[repo]]
-url = "https://github.com/Electron-Cash/android-vendor-freebsd"
-
-[[repo]]
 url = "https://github.com/Electron-Cash/buildozer"
 
 [[repo]]


### PR DESCRIPTION
Removal of copied repos for Electron Cash (clones of FreeBSD and the Android NDK with no changes). These add several hundred thousand commits to index but are in no way Bitcoin Cash repos.