### PR TITLE
Add various projects to the Solana and Serum ecosystem pages

### DIFF
--- a/data/ecosystems/p/project-serum.toml
+++ b/data/ecosystems/p/project-serum.toml
@@ -50,3 +50,9 @@ url = "https://github.com/project-serum/swap-ts"
 
 [[repo]]
 url = "https://github.com/project-serum/validators"
+
+[[repo]]
+url = "https://github.com/dr497/serum-academy"
+
+[[repo]]
+url = "https://github.com/tardis-dev/serum-machine"

--- a/data/ecosystems/s/solana.toml
+++ b/data/ecosystems/s/solana.toml
@@ -323,3 +323,48 @@ url = "https://github.com/zemse/solana-rust-contract"
 
 [[repo]]
 url = "https://github.com/Zergity/static"
+
+[[repo]]
+url = "https://github.com/paul-schaaf/awesome-solana"
+
+[[repo]]
+url = "https://github.com/mathwallet/math-solana-js"
+
+[[repo]]
+url = "https://github.com/michaelhly/stable-swap-program"
+
+[[repo]]
+url = "https://github.com/DescartesNetwork/soprox"
+
+[[repo]]
+url = "https://github.com/paul-schaaf/solbot"
+
+[[repo]]
+url = "https://github.com/renproject/ren-solana"
+
+[[repo]]
+url = "https://github.com/InCrypto-io/solana-dice"
+
+[[repo]]
+url = "https://github.com/mcf-rocks/simple-vote-tutorial"
+
+[[repo]]
+url = "https://github.com/mcf-rocks/solana-upload"
+
+[[repo]]
+url = "https://github.com/paul-schaaf/spl-token-ui"
+
+[[repo]]
+url = "https://github.com/vidorge/solflare-decrypt"
+
+[[repo]]
+url = "https://github.com/paul-schaaf/solchess"
+
+[[repo]]
+url = "https://github.com/andrey-do/solletmobile"
+
+[[repo]]
+url = "https://github.com/everstake/tagger"
+
+[[repo]]
+url = "https://github.com/kemargrant/soltalk"


### PR DESCRIPTION
A few projects related to Solana and Serum were missing from their pertaining ecosystem files. I went ahead and added the missing projects to each.

An open question: Solana has multiple partnerships announced [here](https://solana.com/ecosystem) that don't have public GitHub links. I noticed that only git repositories are being added — should I leave these partnerships and engagements out or add in the relevant announcements on other domains?

Many thanks.