### PR TITLE
Added ipfs-shipyard to ipfs orgs

### DIFF
--- a/data/ecosystems/i/ipfs.toml
+++ b/data/ecosystems/i/ipfs.toml
@@ -3,7 +3,7 @@ title = "IPFS"
 
 sub_ecosystems = ["Berty", "OrbitDB"]
 
-github_organizations = ["https://github.com/ipfs"]
+github_organizations = ["https://github.com/ipfs", "https://github.com/ipfs-shipyard"]
 
 # Repositories
 [[repo]]


### PR DESCRIPTION
There are 138 extra repos in https://github.com/ipfs-shipyard/ that contribute to the IPFS ecosystem