### PR TITLE
Update list of Dfinity (internet computer) projects

### DIFF
--- a/data/ecosystems/d/dfinity.toml
+++ b/data/ecosystems/d/dfinity.toml
@@ -4,14 +4,371 @@ title = "DFINITY"
 sub_ecosystems = []
 
 github_organizations = [
+  "https://github.com/1082-xyz",
+  "https://github.com/109km",
+  "https://github.com/3cL1p5e7",
+  "https://github.com/55foundry",
+  "https://github.com/aitikgupta",
+  "https://github.com/ajerni",
+  "https://github.com/allusion-be",
+  "https://github.com/alyleite",
+  "https://github.com/amaralc",
+  "https://github.com/amitcz",
+  "https://github.com/Ancez",
+  "https://github.com/AndyOsei",
+  "https://github.com/andyzal",
+  "https://github.com/anthonymq",
+  "https://github.com/armaangoel78",
+  "https://github.com/AstroxNetwork",
+  "https://github.com/aviate-labs",
+  "https://github.com/b0xtch",
+  "https://github.com/badoet",
+  "https://github.com/BerkeleyBlockchain",
+  "https://github.com/beyond009",
+  "https://github.com/bianyuanop",
+  "https://github.com/BigBrotherTR",
+  "https://github.com/blynn",
+  "https://github.com/BookieOandasan",
+  "https://github.com/BrianCottrell",
+  "https://github.com/brson",
+  "https://github.com/buraksenyurt",
+  "https://github.com/CapsicumCorp",
+  "https://github.com/C-B-Elite",
+  "https://github.com/ccyanxyz",
+  "https://github.com/Ceto-Labs",
+  "https://github.com/chachaxw",
+  "https://github.com/chenyan2002",
+  "https://github.com/christophediprima",
+  "https://github.com/Cj-bc",
+  "https://github.com/ClankPan",
+  "https://github.com/contentflydapp",
+  "https://github.com/corest",
+  "https://github.com/credfeto",
+  "https://github.com/Crinstaniev",
+  "https://github.com/cristianoc",
+  "https://github.com/crusso",
+  "https://github.com/daichi000",
+  "https://github.com/Daniel-Bloom-dfinity",
+  "https://github.com/dansteren",
+  "https://github.com/dappblock",
+  "https://github.com/davebland",
+  "https://github.com/davetowey",
+  "https://github.com/davidmitesh",
+  "https://github.com/davidp94",
+  "https://github.com/deckgo",
+  "https://github.com/Deland-Labs",
+  "https://github.com/DepartureLabsIC",
+  "https://github.com/der0pa",
+  "https://github.com/desirekaleba",
+  "https://github.com/dfinance-tech",
+  "https://github.com/dfinihack-team5",
   "https://github.com/dfinity",
+  "https://github.com/Dfinity-Bjoern",
+  "https://github.com/DFINITY-Education",
+  "https://github.com/dfinity-lab",
+  "https://github.com/Di-Box",
+  "https://github.com/dmailofficial",
+  "https://github.com/DoWithPassion",
+  "https://github.com/dprats",
   "https://github.com/dragginzgame",
+  "https://github.com/dsarlis",
+  "https://github.com/dscvr-one",
+  "https://github.com/Duke-CS-Plus-IC",
+  "https://github.com/duke-sunshine",
+  "https://github.com/dushaobindoudou",
+  "https://github.com/dylanpaul",
+  "https://github.com/e274426380",
+  "https://github.com/ECNUwyzZL",
+  "https://github.com/egeyar",
+  "https://github.com/emilniklas",
+  "https://github.com/Entropy-Foundation",
+  "https://github.com/enzoh",
+  "https://github.com/esensconsulting",
+  "https://github.com/farazshaikh",
+  "https://github.com/ferMartz",
+  "https://github.com/fifteen42",
+  "https://github.com/FleekHQ",
+  "https://github.com/FloorLamp",
+  "https://github.com/flyq",
+  "https://github.com/foolingdutchman",
+  "https://github.com/functionland",
+  "https://github.com/gabrielnic",
+  "https://github.com/garyjs",
+  "https://github.com/getimpactnow",
+  "https://github.com/gobengo",
+  "https://github.com/gschian0",
+  "https://github.com/GuoyiZhang",
+  "https://github.com/HammadKhalid101",
+  "https://github.com/hansl",
+  "https://github.com/Harrolee",
+  "https://github.com/hashquark-io",
+  "https://github.com/hencoole",
+  "https://github.com/hhzule",
+  "https://github.com/himyyy",
+  "https://github.com/horford",
+  "https://github.com/iBridge-up",
+  "https://github.com/IC-Drive",
+  "https://github.com/icper",
+  "https://github.com/ICP-Foundation",
+  "https://github.com/icplabs",
+  "https://github.com/ic-rocks",
+  "https://github.com/idkjs",
+  "https://github.com/ililic",
+  "https://github.com/Internet-Computer-Code-Stream",
+  "https://github.com/InternetComputerOG",
+  "https://github.com/Jackieyewang",
+  "https://github.com/jakepeg",
+  "https://github.com/janeshchhabra",
+  "https://github.com/Janmajayamall",
+  "https://github.com/Jesse989",
+  "https://github.com/jkmartindale",
+  "https://github.com/j-mendez",
+  "https://github.com/johanforslund",
+  "https://github.com/johnkruger37",
+  "https://github.com/jorgenbuilder",
+  "https://github.com/joshbenaron",
+  "https://github.com/jplevyak",
+  "https://github.com/justmoo",
+  "https://github.com/kifran72",
+  "https://github.com/kristoferlund",
+  "https://github.com/kritzcreek",
+  "https://github.com/krpeacock",
+  "https://github.com/lastmjs",
+  "https://github.com/lazy1523",
+  "https://github.com/leo-icp",
+  "https://github.com/lesterli",
+  "https://github.com/LexiccLabs",
+  "https://github.com/linkremix2021",
+  "https://github.com/liqMix",
+  "https://github.com/lsgunnlsgunn",
+  "https://github.com/lshoo",
+  "https://github.com/machenjie",
+  "https://github.com/Magvin",
+  "https://github.com/Mansonpj",
+  "https://github.com/marksix",
+  "https://github.com/marspoolxyz",
+  "https://github.com/matthewhammer",
+  "https://github.com/maurycy",
+  "https://github.com/metascore",
+  "https://github.com/mingming-tang",
+  "https://github.com/MioQuispe",
+  "https://github.com/mitulap",
+  "https://github.com/muses-fm",
+  "https://github.com/NEBCLab",
+  "https://github.com/NFT-team",
+  "https://github.com/nguyennguyen1112000",
+  "https://github.com/nhihtnguyen",
+  "https://github.com/Nima-Ra",
+  "https://github.com/ninegua",
+  "https://github.com/NnsDao",
+  "https://github.com/nomeata",
+  "https://github.com/nzoghb",
+  "https://github.com/octalmage",
+  "https://github.com/OpenCan-io",
+  "https://github.com/open-ic",
+  "https://github.com/Open-Sourced-Olaf",
+  "https://github.com/ORIGYN-SA",
+  "https://github.com/oumlahade",
+  "https://github.com/Pabsysop",
+  "https://github.com/panacloud-modern-global-apps",
+  "https://github.com/peterpeterparker",
+  "https://github.com/PeterRusznak",
+  "https://github.com/phase-all",
+  "https://github.com/PhilipZubel",
+  "https://github.com/picsoung",
+  "https://github.com/pisekchaiold",
+  "https://github.com/p-shahi",
+  "https://github.com/Psychedelic",
+  "https://github.com/QiuYeDx",
+  "https://github.com/qkl-repo",
+  "https://github.com/qti3e",
+  "https://github.com/ramonne69",
+  "https://github.com/rbolog",
+  "https://github.com/rckprtr",
+  "https://github.com/rdiaz82",
+  "https://github.com/Rhys-Banerjee",
+  "https://github.com/ringockmg",
+  "https://github.com/robtoof",
+  "https://github.com/roman-agentic",
+  "https://github.com/rouven-d",
+  "https://github.com/rstout",
+  "https://github.com/saikatdas0790",
   "https://github.com/sailfish-app",
+  "https://github.com/sakanosita",
+  "https://github.com/samjiks",
+  "https://github.com/SamueleA",
+  "https://github.com/SantiagoDePolonia",
+  "https://github.com/SebThuillier",
+  "https://github.com/seniorjoinu",
+  "https://github.com/sentientforest",
+  "https://github.com/shalexbas",
+  "https://github.com/shawndotey",
+  "https://github.com/shawnrmoss",
+  "https://github.com/Sirtwitter",
+  "https://github.com/spencerbug",
+  "https://github.com/stanleygjones",
+  "https://github.com/stephenandrews",
+  "https://github.com/SteveMaybe",
+  "https://github.com/stopak",
+  "https://github.com/studna",
+  "https://github.com/SuddenlyHazel",
+  "https://github.com/sudograph",
+  "https://github.com/tahublockchain",
+  "https://github.com/tarek-eg",
+  "https://github.com/taylorham",
+  "https://github.com/tglaeser",
+  "https://github.com/thmufl",
+  "https://github.com/timohanke",
+  "https://github.com/Toniq-Labs",
+  "https://github.com/tuvs85",
+  "https://github.com/udinnet",
+  "https://github.com/umeklinks",
+  "https://github.com/uney",
+  "https://github.com/vanguard88728",
+  "https://github.com/vartiukh",
+  "https://github.com/vikrembhagi",
+  "https://github.com/warashibe",
+  "https://github.com/wcannon",
+  "https://github.com/webcoderz",
+  "https://github.com/webi-ai",
+  "https://github.com/wildmouse",
+  "https://github.com/witterlee",
+  "https://github.com/wlchn",
+  "https://github.com/wshchqdxdxsh",
+  "https://github.com/yanbowen1994",
+  "https://github.com/yosadchyi",
+  "https://github.com/yourkungfunogood",
+  "https://github.com/yuta17",
+  "https://github.com/z330789559",
+  "https://github.com/zhangjiujiang",
 ]
 
 # Repositories
 [[repo]]
+url = "https://github.com/1082-xyz/ic-china"
+
+[[repo]]
+url = "https://github.com/109km/blockchain-tutorials"
+
+[[repo]]
+url = "https://github.com/3cL1p5e7/rust-identity-template"
+
+[[repo]]
+url = "https://github.com/55foundry/DIP20"
+
+[[repo]]
+url = "https://github.com/aitikgupta/DFPRunner"
+
+[[repo]]
+url = "https://github.com/ajerni/dfinitytest"
+
+[[repo]]
+url = "https://github.com/ajerni/icfleek"
+
+[[repo]]
+url = "https://github.com/allusion-be/ic-static"
+
+[[repo]]
+url = "https://github.com/allusion-be/ic-ts"
+
+[[repo]]
+url = "https://github.com/alyleite/icp-makers-test"
+
+[[repo]]
+url = "https://github.com/amaralc/dfinty-hello-world"
+
+[[repo]]
+url = "https://github.com/amaralc/pl-ic"
+
+[[repo]]
+url = "https://github.com/amitcz/canister-call-rust"
+
+[[repo]]
+url = "https://github.com/Ancez/sudograph-vue"
+
+[[repo]]
+url = "https://github.com/AndyOsei/dfinity-no-backend"
+
+[[repo]]
+url = "https://github.com/andyzal/icstatica"
+
+[[repo]]
 url = "https://github.com/anthonymq/gomoku-dfn"
+
+[[repo]]
+url = "https://github.com/anthonymq/stock-inventory-dfn"
+
+[[repo]]
+url = "https://github.com/anthonymq/stock-inventory-dfn-old"
+
+[[repo]]
+url = "https://github.com/armaangoel78/DfinityTodo"
+
+[[repo]]
+url = "https://github.com/AstroxNetwork/agent_dart_examples"
+
+[[repo]]
+url = "https://github.com/aviate-labs/asset-storage.mo"
+
+[[repo]]
+url = "https://github.com/aviate-labs/principal.mo"
+
+[[repo]]
+url = "https://github.com/b0xtch/dfx_rust"
+
+[[repo]]
+url = "https://github.com/badoet/plumbum"
+
+[[repo]]
+url = "https://github.com/BerkeleyBlockchain/dfinity-research"
+
+[[repo]]
+url = "https://github.com/beyond009/icplabs"
+
+[[repo]]
+url = "https://github.com/bianyuanop/source-store-motoko"
+
+[[repo]]
+url = "https://github.com/BigBrotherTR/linkedup-test"
+
+[[repo]]
+url = "https://github.com/blynn/sidekick"
+
+[[repo]]
+url = "https://github.com/BookieOandasan/dFinityHello"
+
+[[repo]]
+url = "https://github.com/BrianCottrell/Shadow"
+
+[[repo]]
+url = "https://github.com/brson/rust-contract-comparison"
+
+[[repo]]
+url = "https://github.com/buraksenyurt/skynet"
+
+[[repo]]
+url = "https://github.com/CapsicumCorp/house-book"
+
+[[repo]]
+url = "https://github.com/C-B-Elite/ERC721"
+
+[[repo]]
+url = "https://github.com/C-B-Elite/exp"
+
+[[repo]]
+url = "https://github.com/C-B-Elite/StableStorage"
+
+[[repo]]
+url = "https://github.com/C-B-Elite/test"
+
+[[repo]]
+url = "https://github.com/ccyanxyz/dfn"
+
+[[repo]]
+url = "https://github.com/Ceto-Labs/ceto-swap-website"
+
+[[repo]]
+url = "https://github.com/chachaxw/icp-starter-app"
 
 [[repo]]
 url = "https://github.com/chenyan2002/ic-elm"
@@ -20,7 +377,127 @@ url = "https://github.com/chenyan2002/ic-elm"
 url = "https://github.com/chenyan2002/ic-logo"
 
 [[repo]]
+url = "https://github.com/christophediprima/dfinity_dip_test"
+
+[[repo]]
+url = "https://github.com/Cj-bc/playground"
+
+[[repo]]
+url = "https://github.com/ClankPan/PuzzleAttacker"
+
+[[repo]]
+url = "https://github.com/contentflydapp/eventd"
+
+[[repo]]
+url = "https://github.com/corest/dfinity-demo"
+
+[[repo]]
+url = "https://github.com/credfeto/dfinity-scratch"
+
+[[repo]]
+url = "https://github.com/Crinstaniev/dfinity-vite"
+
+[[repo]]
+url = "https://github.com/Crinstaniev/ic-sciecon-demo-app"
+
+[[repo]]
+url = "https://github.com/Crinstaniev/phonebook-ic"
+
+[[repo]]
+url = "https://github.com/Crinstaniev/reaction-game-dfinity-vue"
+
+[[repo]]
+url = "https://github.com/Crinstaniev/reaction-timer"
+
+[[repo]]
+url = "https://github.com/cristianoc/rescript-motoko"
+
+[[repo]]
+url = "https://github.com/crusso/burn"
+
+[[repo]]
+url = "https://github.com/crusso/random_maze"
+
+[[repo]]
+url = "https://github.com/crusso/shield"
+
+[[repo]]
+url = "https://github.com/crusso/TimeExample"
+
+[[repo]]
+url = "https://github.com/daichi000/hello-dfinity"
+
+[[repo]]
+url = "https://github.com/Daniel-Bloom-dfinity/team3"
+
+[[repo]]
+url = "https://github.com/dansteren/dfinity_rust_starter"
+
+[[repo]]
+url = "https://github.com/dansteren/files"
+
+[[repo]]
+url = "https://github.com/dansteren/files-sudograph"
+
+[[repo]]
+url = "https://github.com/dappblock/nextjs-ic-starter"
+
+[[repo]]
+url = "https://github.com/davebland/ic_guestbook"
+
+[[repo]]
+url = "https://github.com/davetowey/orb-zero"
+
+[[repo]]
+url = "https://github.com/davidmitesh/dfinity-explore"
+
+[[repo]]
+url = "https://github.com/davidp94/icqs-demo"
+
+[[repo]]
 url = "https://github.com/davidp94/vue_examples_frontend_dfx"
+
+[[repo]]
+url = "https://github.com/deckgo/deckdeckgo"
+
+[[repo]]
+url = "https://github.com/Deland-Labs/dfinity-fungible-token-standard"
+
+[[repo]]
+url = "https://github.com/Deland-Labs/dfinity-self-describing-standard"
+
+[[repo]]
+url = "https://github.com/Deland-Labs/dft-issuance-tool"
+
+[[repo]]
+url = "https://github.com/DepartureLabsIC/non-fungible-token"
+
+[[repo]]
+url = "https://github.com/der0pa/helloIC"
+
+[[repo]]
+url = "https://github.com/der0pa/seven_seven"
+
+[[repo]]
+url = "https://github.com/der0pa/sqlite_interp"
+
+[[repo]]
+url = "https://github.com/der0pa/wiki"
+
+[[repo]]
+url = "https://github.com/desirekaleba/fantastic-place"
+
+[[repo]]
+url = "https://github.com/desirekaleba/IC-practs"
+
+[[repo]]
+url = "https://github.com/dfinance-tech/ic-token"
+
+[[repo]]
+url = "https://github.com/dfinance-tech/read_rs"
+
+[[repo]]
+url = "https://github.com/dfinihack-team5/dfinihack"
 
 [[repo]]
 url = "https://github.com/dfinity/agent-js"
@@ -41,6 +518,9 @@ url = "https://github.com/dfinity/assets-rs"
 url = "https://github.com/dfinity/awesome-dfinity"
 
 [[repo]]
+url = "https://github.com/Dfinity-Bjoern/Magnify"
+
+[[repo]]
 url = "https://github.com/dfinity/bls"
 
 [[repo]]
@@ -57,6 +537,9 @@ url = "https://github.com/dfinity/candid"
 
 [[repo]]
 url = "https://github.com/dfinity/cdk-rs"
+
+[[repo]]
+url = "https://github.com/dfinity/certified-assets"
 
 [[repo]]
 url = "https://github.com/dfinity/certified-map"
@@ -82,6 +565,27 @@ url = "https://github.com/dfinity/docs"
 
 [[repo]]
 url = "https://github.com/dfinity/duosign"
+
+[[repo]]
+url = "https://github.com/DFINITY-Education/blockchain-and-cryptocurrency"
+
+[[repo]]
+url = "https://github.com/DFINITY-Education/data-structures"
+
+[[repo]]
+url = "https://github.com/DFINITY-Education/distributed-systems"
+
+[[repo]]
+url = "https://github.com/DFINITY-Education/governance"
+
+[[repo]]
+url = "https://github.com/DFINITY-Education/programming-languages"
+
+[[repo]]
+url = "https://github.com/DFINITY-Education/protocol-design"
+
+[[repo]]
+url = "https://github.com/DFINITY-Education/web-development"
 
 [[repo]]
 url = "https://github.com/dfinity/examples"
@@ -169,6 +673,9 @@ url = "https://github.com/dfinity/js-primea-wasm-system-interface"
 
 [[repo]]
 url = "https://github.com/dfinity/keysmith"
+
+[[repo]]
+url = "https://github.com/dfinity-lab/phonebook"
 
 [[repo]]
 url = "https://github.com/dfinity/linkedup"
@@ -279,6 +786,27 @@ url = "https://github.com/dfinity/wasm-profiler"
 url = "https://github.com/dfinity/winter"
 
 [[repo]]
+url = "https://github.com/Di-Box/Storage"
+
+[[repo]]
+url = "https://github.com/dmailofficial/backend"
+
+[[repo]]
+url = "https://github.com/dmailofficial/dmail"
+
+[[repo]]
+url = "https://github.com/DoWithPassion/TodoDfinity"
+
+[[repo]]
+url = "https://github.com/dprats/icp-ecosystem"
+
+[[repo]]
+url = "https://github.com/dprats/submit_nns_proposal_tutorial"
+
+[[repo]]
+url = "https://github.com/dprats/twitter-canister-ic"
+
+[[repo]]
 url = "https://github.com/dragginzgame/dragginz"
 
 [[repo]]
@@ -294,7 +822,55 @@ url = "https://github.com/dragginzgame/dragginz-website"
 url = "https://github.com/dragginzgame/dragginz-world-editor"
 
 [[repo]]
+url = "https://github.com/dsarlis/ic-butler"
+
+[[repo]]
+url = "https://github.com/dscvr-one/ic-drip"
+
+[[repo]]
+url = "https://github.com/Duke-CS-Plus-IC/Waterpark"
+
+[[repo]]
+url = "https://github.com/duke-sunshine/ic-oer-react"
+
+[[repo]]
+url = "https://github.com/duke-sunshine/location-hello"
+
+[[repo]]
+url = "https://github.com/dushaobindoudou/dfinity_vue"
+
+[[repo]]
+url = "https://github.com/dylanpaul/ICy"
+
+[[repo]]
+url = "https://github.com/dylanpaul/ICy2"
+
+[[repo]]
+url = "https://github.com/e274426380/dfx_ele_test"
+
+[[repo]]
+url = "https://github.com/e274426380/dfx_icpleague"
+
+[[repo]]
+url = "https://github.com/ECNUwyzZL/blog"
+
+[[repo]]
+url = "https://github.com/egeyar/wochonecha"
+
+[[repo]]
+url = "https://github.com/emilniklas/emilbroman.me"
+
+[[repo]]
+url = "https://github.com/Entropy-Foundation/dfinity-poc"
+
+[[repo]]
 url = "https://github.com/enzoh/actor-refs"
+
+[[repo]]
+url = "https://github.com/enzoh/chronosphere"
+
+[[repo]]
+url = "https://github.com/enzoh/counter"
 
 [[repo]]
 url = "https://github.com/enzoh/create-dfinity-app"
@@ -330,25 +906,382 @@ url = "https://github.com/enzoh/sovereign"
 url = "https://github.com/enzoh/superheroes"
 
 [[repo]]
+url = "https://github.com/esensconsulting/Belisama"
+
+[[repo]]
+url = "https://github.com/esensconsulting/dfinity-demo"
+
+[[repo]]
+url = "https://github.com/esensconsulting/IC-stock-inventory"
+
+[[repo]]
+url = "https://github.com/esensconsulting/KanbanIC"
+
+[[repo]]
+url = "https://github.com/farazshaikh/team14"
+
+[[repo]]
+url = "https://github.com/ferMartz/ic-firestarter"
+
+[[repo]]
+url = "https://github.com/ferMartz/ic-material-playground"
+
+[[repo]]
+url = "https://github.com/ferMartz/ic-playground"
+
+[[repo]]
+url = "https://github.com/ferMartz/ic-template-react-tw"
+
+[[repo]]
+url = "https://github.com/fifteen42/djob"
+
+[[repo]]
+url = "https://github.com/FleekHQ/IC-Deploy-Action"
+
+[[repo]]
+url = "https://github.com/FloorLamp/axon"
+
+[[repo]]
+url = "https://github.com/FloorLamp/cubic"
+
+[[repo]]
+url = "https://github.com/FloorLamp/dfinity-react-ts-tailwind-starter"
+
+[[repo]]
+url = "https://github.com/FloorLamp/drip-land"
+
+[[repo]]
+url = "https://github.com/flyq/await_test"
+
+[[repo]]
+url = "https://github.com/flyq/candid_rs_exam"
+
+[[repo]]
+url = "https://github.com/flyq/ic_codec"
+
+[[repo]]
+url = "https://github.com/flyq/ic-course"
+
+[[repo]]
+url = "https://github.com/flyq/inter_call"
+
+[[repo]]
+url = "https://github.com/flyq/inter_canister"
+
+[[repo]]
+url = "https://github.com/flyq/lock_test"
+
+[[repo]]
+url = "https://github.com/flyq/motoko-sha224"
+
+[[repo]]
+url = "https://github.com/flyq/motoko_token"
+
+[[repo]]
+url = "https://github.com/flyq/rust_dfinity_hello"
+
+[[repo]]
+url = "https://github.com/flyq/testinter"
+
+[[repo]]
+url = "https://github.com/flyq/whoami"
+
+[[repo]]
+url = "https://github.com/foolingdutchman/icat"
+
+[[repo]]
+url = "https://github.com/functionland/dfinity"
+
+[[repo]]
+url = "https://github.com/functionland/photos"
+
+[[repo]]
+url = "https://github.com/gabrielnic/dfinity-react"
+
+[[repo]]
+url = "https://github.com/gabrielnic/motoko-cdn"
+
+[[repo]]
+url = "https://github.com/garyjs/dfinity-coming-soon-html5-boilerplate"
+
+[[repo]]
 url = "https://github.com/getimpactnow/getimpactnow"
+
+[[repo]]
+url = "https://github.com/gobengo/ic-whoami"
+
+[[repo]]
+url = "https://github.com/gobengo/myface"
+
+[[repo]]
+url = "https://github.com/gschian0/custom_greeting"
+
+[[repo]]
+url = "https://github.com/GuoyiZhang/078-Vue-resumeVue"
+
+[[repo]]
+url = "https://github.com/HammadKhalid101/Dfinity"
+
+[[repo]]
+url = "https://github.com/hansl/dfx-demo"
+
+[[repo]]
+url = "https://github.com/hansl/dfx-schematics"
+
+[[repo]]
+url = "https://github.com/hansl/journey"
+
+[[repo]]
+url = "https://github.com/Harrolee/internetcomputer_demo"
 
 [[repo]]
 url = "https://github.com/hashquark-io/nnsExplorer"
 
 [[repo]]
+url = "https://github.com/hencoole/doudizhu"
+
+[[repo]]
+url = "https://github.com/hhzule/icp-motoko"
+
+[[repo]]
+url = "https://github.com/hhzule/internet-computer"
+
+[[repo]]
+url = "https://github.com/himyyy/react_dfinity"
+
+[[repo]]
+url = "https://github.com/horford/harryorford-portfolio"
+
+[[repo]]
+url = "https://github.com/iBridge-up/bridge-dapp"
+
+[[repo]]
+url = "https://github.com/iBridge-up/ibridge-dfinity"
+
+[[repo]]
+url = "https://github.com/IC-Drive/ic-drive"
+
+[[repo]]
+url = "https://github.com/icper/cancan"
+
+[[repo]]
+url = "https://github.com/icper/examples"
+
+[[repo]]
+url = "https://github.com/icper/motoko-token"
+
+[[repo]]
+url = "https://github.com/ICP-Foundation/helloworld"
+
+[[repo]]
+url = "https://github.com/icplabs/aggregator"
+
+[[repo]]
+url = "https://github.com/ic-rocks/metrics"
+
+[[repo]]
+url = "https://github.com/idkjs/calculator"
+
+[[repo]]
+url = "https://github.com/idkjs/calculator2"
+
+[[repo]]
+url = "https://github.com/ililic/motoko_base_library_test_battery"
+
+[[repo]]
+url = "https://github.com/Internet-Computer-Code-Stream/NFT-video"
+
+[[repo]]
+url = "https://github.com/InternetComputerOG/IC-Contact_Form_Demo"
+
+[[repo]]
+url = "https://github.com/InternetComputerOG/IC-hello-demo"
+
+[[repo]]
+url = "https://github.com/Jackieyewang/Blockchain-learning"
+
+[[repo]]
+url = "https://github.com/jakepeg/doo-coins"
+
+[[repo]]
+url = "https://github.com/janeshchhabra/dfinity-team-14"
+
+[[repo]]
+url = "https://github.com/Janmajayamall/dfc-dfinity"
+
+[[repo]]
+url = "https://github.com/Jesse989/portfolio"
+
+[[repo]]
+url = "https://github.com/jkmartindale/ethical_targeting-backend"
+
+[[repo]]
+url = "https://github.com/j-mendez/zelephant"
+
+[[repo]]
+url = "https://github.com/johanforslund/hello-dfinity"
+
+[[repo]]
+url = "https://github.com/johnkruger37/learn-internetcomputer"
+
+[[repo]]
+url = "https://github.com/jorgenbuilder/ext-nft-example"
+
+[[repo]]
+url = "https://github.com/jorgenbuilder/heartbeat"
+
+[[repo]]
+url = "https://github.com/jorgenbuilder/nft-betadeck"
+
+[[repo]]
+url = "https://github.com/jorgenbuilder/saga"
+
+[[repo]]
+url = "https://github.com/jorgenbuilder/tarotdeck"
+
+[[repo]]
+url = "https://github.com/joshbenaron/ic-assignment"
+
+[[repo]]
+url = "https://github.com/jplevyak/dfnhack7"
+
+[[repo]]
+url = "https://github.com/justmoo/hello-world-canister"
+
+[[repo]]
+url = "https://github.com/kifran72/monkey"
+
+[[repo]]
+url = "https://github.com/kristoferlund/ic-wall"
+
+[[repo]]
+url = "https://github.com/kritzcreek/dAppreciate"
+
+[[repo]]
+url = "https://github.com/kritzcreek/ic101"
+
+[[repo]]
+url = "https://github.com/kritzcreek/mo-hex"
+
+[[repo]]
 url = "https://github.com/kritzcreek/motoko-matchers"
+
+[[repo]]
+url = "https://github.com/kritzcreek/ps_canister"
 
 [[repo]]
 url = "https://github.com/kritzcreek/vessel"
 
 [[repo]]
+url = "https://github.com/krpeacock/auth-client-demo"
+
+[[repo]]
+url = "https://github.com/krpeacock/canvas"
+
+[[repo]]
+url = "https://github.com/krpeacock/dfinity-expo-proof-of-concept"
+
+[[repo]]
+url = "https://github.com/krpeacock/dfx-new-0.7.6"
+
+[[repo]]
+url = "https://github.com/krpeacock/dfx-template-react"
+
+[[repo]]
+url = "https://github.com/krpeacock/file_upload_experiment"
+
+[[repo]]
+url = "https://github.com/krpeacock/ic-avatar"
+
+[[repo]]
+url = "https://github.com/krpeacock/ic-avatar-samples"
+
+[[repo]]
+url = "https://github.com/krpeacock/ic-static-minimal"
+
+[[repo]]
+url = "https://github.com/krpeacock/ic-vcf-gatsby"
+
+[[repo]]
+url = "https://github.com/krpeacock/page-visits"
+
+[[repo]]
+url = "https://github.com/krpeacock/simple-to-do"
+
+[[repo]]
+url = "https://github.com/lastmjs/demergence"
+
+[[repo]]
+url = "https://github.com/lastmjs/ethereum-archival-canister"
+
+[[repo]]
 url = "https://github.com/lastmjs/graphql-icp"
+
+[[repo]]
+url = "https://github.com/lazy1523/Dfinity_YYDS"
+
+[[repo]]
+url = "https://github.com/leo-icp/block-chain-wallet"
+
+[[repo]]
+url = "https://github.com/lesterli/rust-practice"
+
+[[repo]]
+url = "https://github.com/LexiccLabs/ChaacNet"
+
+[[repo]]
+url = "https://github.com/linkremix2021/dfx_react_app"
+
+[[repo]]
+url = "https://github.com/liqMix/DPlay"
+
+[[repo]]
+url = "https://github.com/lsgunnlsgunn/ic-docs"
+
+[[repo]]
+url = "https://github.com/lshoo/auction_dapp"
+
+[[repo]]
+url = "https://github.com/machenjie/2048Game"
+
+[[repo]]
+url = "https://github.com/Magvin/nextjs-icp"
+
+[[repo]]
+url = "https://github.com/Mansonpj/BlackT"
+
+[[repo]]
+url = "https://github.com/marksix/ICP"
+
+[[repo]]
+url = "https://github.com/marspoolxyz/ic0_MarsPool"
+
+[[repo]]
+url = "https://github.com/marspoolxyz/mugaNFT"
+
+[[repo]]
+url = "https://github.com/marspoolxyz/no_backend"
+
+[[repo]]
+url = "https://github.com/marspoolxyz/soundnodes"
+
+[[repo]]
+url = "https://github.com/matthewhammer/candid-spaces"
+
+[[repo]]
+url = "https://github.com/matthewhammer/cleansheets"
 
 [[repo]]
 url = "https://github.com/matthewhammer/cra-template-dfn"
 
 [[repo]]
 url = "https://github.com/matthewhammer/ic-game-terminal"
+
+[[repo]]
+url = "https://github.com/matthewhammer/ic-mini-terminal"
+
+[[repo]]
+url = "https://github.com/matthewhammer/mohammer"
 
 [[repo]]
 url = "https://github.com/matthewhammer/motoko-adapton"
@@ -358,6 +1291,9 @@ url = "https://github.com/matthewhammer/motoko-bigsearch"
 
 [[repo]]
 url = "https://github.com/matthewhammer/motoko-bigtest"
+
+[[repo]]
+url = "https://github.com/matthewhammer/motoko-convex2d"
 
 [[repo]]
 url = "https://github.com/matthewhammer/motoko-crud"
@@ -378,10 +1314,244 @@ url = "https://github.com/matthewhammer/motoko-sequence"
 url = "https://github.com/matthewhammer/motoko-stand"
 
 [[repo]]
+url = "https://github.com/matthewhammer/shift-left"
+
+[[repo]]
+url = "https://github.com/maurycy/dfx-poc-http-proxy"
+
+[[repo]]
+url = "https://github.com/maurycy/dfx-static-hosting-template"
+
+[[repo]]
+url = "https://github.com/metascore/Metaquizz"
+
+[[repo]]
+url = "https://github.com/metascore/metarank"
+
+[[repo]]
+url = "https://github.com/metascore/metascore"
+
+[[repo]]
+url = "https://github.com/metascore/stress"
+
+[[repo]]
+url = "https://github.com/metascore/tourney"
+
+[[repo]]
+url = "https://github.com/mingming-tang/dfinity-vue"
+
+[[repo]]
 url = "https://github.com/MioQuispe/create-dfinity-app"
 
 [[repo]]
+url = "https://github.com/MioQuispe/create-ic-app"
+
+[[repo]]
+url = "https://github.com/mitulap/internet_computer_tutorial"
+
+[[repo]]
+url = "https://github.com/muses-fm/muses"
+
+[[repo]]
+url = "https://github.com/NEBCLab/DFINITY"
+
+[[repo]]
+url = "https://github.com/NEBCLab/exp"
+
+[[repo]]
+url = "https://github.com/NFT-team/creatures"
+
+[[repo]]
+url = "https://github.com/NFT-team/nft-token"
+
+[[repo]]
+url = "https://github.com/nguyennguyen1112000/dfinity"
+
+[[repo]]
+url = "https://github.com/nhihtnguyen/Dfinity-CRUD-example"
+
+[[repo]]
+url = "https://github.com/Nima-Ra/FleekAssignment"
+
+[[repo]]
+url = "https://github.com/ninegua/reversi"
+
+[[repo]]
+url = "https://github.com/ninegua/tipjar"
+
+[[repo]]
+url = "https://github.com/NnsDao/icpscan"
+
+[[repo]]
+url = "https://github.com/NnsDao/ICTexas"
+
+[[repo]]
+url = "https://github.com/NnsDao/nnsdao-org"
+
+[[repo]]
+url = "https://github.com/NnsDao/nns-motoko-token"
+
+[[repo]]
+url = "https://github.com/nomeata/capture-the-ic-token"
+
+[[repo]]
 url = "https://github.com/nomeata/haskell-candid"
+
+[[repo]]
+url = "https://github.com/nomeata/ic-telegram-bot"
+
+[[repo]]
+url = "https://github.com/nomeata/motoko-certified-http"
+
+[[repo]]
+url = "https://github.com/nomeata/motoko-sbc2020"
+
+[[repo]]
+url = "https://github.com/nzoghb/ic-kanban"
+
+[[repo]]
+url = "https://github.com/nzoghb/icns"
+
+[[repo]]
+url = "https://github.com/nzoghb/ic-token"
+
+[[repo]]
+url = "https://github.com/nzoghb/motoko-merkle"
+
+[[repo]]
+url = "https://github.com/octalmage/dfinity-guestbook"
+
+[[repo]]
+url = "https://github.com/octalmage/dfinity-ic-cafe"
+
+[[repo]]
+url = "https://github.com/OpenCan-io/BuildMe"
+
+[[repo]]
+url = "https://github.com/open-ic/icp-notifications"
+
+[[repo]]
+url = "https://github.com/open-ic/priv-ic"
+
+[[repo]]
+url = "https://github.com/Open-Sourced-Olaf/Code-Kindle"
+
+[[repo]]
+url = "https://github.com/Open-Sourced-Olaf/DocVerifier"
+
+[[repo]]
+url = "https://github.com/Open-Sourced-Olaf/NalaNet"
+
+[[repo]]
+url = "https://github.com/ORIGYN-SA/motoko_http_handler"
+
+[[repo]]
+url = "https://github.com/ORIGYN-SA/motoko_top_up_canister"
+
+[[repo]]
+url = "https://github.com/oumlahade/decentralized_borrowing_protocol"
+
+[[repo]]
+url = "https://github.com/Pabsysop/PAB_Dfinity"
+
+[[repo]]
+url = "https://github.com/panacloud-modern-global-apps/internet-computer-motoko"
+
+[[repo]]
+url = "https://github.com/peterpeterparker/agentjswebworker"
+
+[[repo]]
+url = "https://github.com/peterpeterparker/stencil-ic-sample"
+
+[[repo]]
+url = "https://github.com/peterpeterparker/transfercycles"
+
+[[repo]]
+url = "https://github.com/PeterRusznak/DfinityBlogEngine"
+
+[[repo]]
+url = "https://github.com/PeterRusznak/Internet_Computer_CRUD_example"
+
+[[repo]]
+url = "https://github.com/PeterRusznak/soc"
+
+[[repo]]
+url = "https://github.com/phase-all/phase-all"
+
+[[repo]]
+url = "https://github.com/PhilipZubel/todo_app_ic"
+
+[[repo]]
+url = "https://github.com/picsoung/dfinity-earthday"
+
+[[repo]]
+url = "https://github.com/pisekchaiold/Test-ic-drive-Bynandit123"
+
+[[repo]]
+url = "https://github.com/p-shahi/calls"
+
+[[repo]]
+url = "https://github.com/Psychedelic/dab"
+
+[[repo]]
+url = "https://github.com/Psychedelic/plug-coinflip"
+
+[[repo]]
+url = "https://github.com/QiuYeDx/ICPLabsWebDir"
+
+[[repo]]
+url = "https://github.com/qkl-repo/dfx-hello"
+
+[[repo]]
+url = "https://github.com/qti3e/ic-bet"
+
+[[repo]]
+url = "https://github.com/ramonne69/dfinity_ninegua"
+
+[[repo]]
+url = "https://github.com/rbolog/dfinity_reactJs_reactRouter_babel"
+
+[[repo]]
+url = "https://github.com/rbolog/motoko-crc"
+
+[[repo]]
+url = "https://github.com/rbolog/qispi_msg_ui"
+
+[[repo]]
+url = "https://github.com/rckprtr/as-dfinity-examples"
+
+[[repo]]
+url = "https://github.com/rckprtr/dfx-backup-restore"
+
+[[repo]]
+url = "https://github.com/rdiaz82/dfinity_cqrs_example"
+
+[[repo]]
+url = "https://github.com/Rhys-Banerjee/csPlusLiquity"
+
+[[repo]]
+url = "https://github.com/Rhys-Banerjee/decentralized_borrowing_protocol2"
+
+[[repo]]
+url = "https://github.com/ringockmg/icp-testing-1"
+
+[[repo]]
+url = "https://github.com/robtoof/web-development"
+
+[[repo]]
+url = "https://github.com/roman-agentic/dfinity-react"
+
+[[repo]]
+url = "https://github.com/roman-agentic/dfxgo"
+
+[[repo]]
+url = "https://github.com/rouven-d/portfolio-rebuild"
+
+[[repo]]
+url = "https://github.com/rstout/bookworm"
+
+[[repo]]
+url = "https://github.com/saikatdas0790/internet-computer-documentation"
 
 [[repo]]
 url = "https://github.com/sailfish-app/chartist-js"
@@ -396,6 +1566,48 @@ url = "https://github.com/sailfish-app/homepage"
 url = "https://github.com/sailfish-app/proposals"
 
 [[repo]]
+url = "https://github.com/sakanosita/motoko-study"
+
+[[repo]]
+url = "https://github.com/samjiks/MiVigor"
+
+[[repo]]
+url = "https://github.com/samjiks/service_provider"
+
+[[repo]]
+url = "https://github.com/SamueleA/github-action-dfinity"
+
+[[repo]]
+url = "https://github.com/SamueleA/github-action-ic-test"
+
+[[repo]]
+url = "https://github.com/SamueleA/ic-github-action-tutorial"
+
+[[repo]]
+url = "https://github.com/SantiagoDePolonia/guestbook_ic"
+
+[[repo]]
+url = "https://github.com/SebThuillier/calculator"
+
+[[repo]]
+url = "https://github.com/SebThuillier/Governance"
+
+[[repo]]
+url = "https://github.com/SebThuillier/Kanban"
+
+[[repo]]
+url = "https://github.com/SebThuillier/MotokoSchool-projects"
+
+[[repo]]
+url = "https://github.com/SebThuillier/Template-Typescript-Phaser3-ESLint"
+
+[[repo]]
+url = "https://github.com/SebThuillier/tic-tac-toe"
+
+[[repo]]
+url = "https://github.com/SebThuillier/Wall-Of-Fame"
+
+[[repo]]
 url = "https://github.com/seniorjoinu/Bonus"
 
 [[repo]]
@@ -403,3 +1615,202 @@ url = "https://github.com/seniorjoinu/candid-gradle-plugin"
 
 [[repo]]
 url = "https://github.com/seniorjoinu/candid-kt"
+
+[[repo]]
+url = "https://github.com/seniorjoinu/ic-cron"
+
+[[repo]]
+url = "https://github.com/seniorjoinu/ic-event-hub"
+
+[[repo]]
+url = "https://github.com/seniorjoinu/tokens"
+
+[[repo]]
+url = "https://github.com/sentientforest/sentientmachinelabs"
+
+[[repo]]
+url = "https://github.com/sentientforest/tutorials"
+
+[[repo]]
+url = "https://github.com/shalexbas/ic-app-vue-3-ts-template"
+
+[[repo]]
+url = "https://github.com/shawndotey/hello-angular-motoko"
+
+[[repo]]
+url = "https://github.com/shawnrmoss/dangular"
+
+[[repo]]
+url = "https://github.com/Sirtwitter/new"
+
+[[repo]]
+url = "https://github.com/spencerbug/spencerneilan.com"
+
+[[repo]]
+url = "https://github.com/stanleygjones/hero-app-generator"
+
+[[repo]]
+url = "https://github.com/stephenandrews/motoko-accountid"
+
+[[repo]]
+url = "https://github.com/SteveMaybe/dfinity-vue-starter"
+
+[[repo]]
+url = "https://github.com/stopak/dpunks"
+
+[[repo]]
+url = "https://github.com/stopak/ICPunks"
+
+[[repo]]
+url = "https://github.com/studna/dfx-static-test"
+
+[[repo]]
+url = "https://github.com/SuddenlyHazel/dfinity-blog"
+
+[[repo]]
+url = "https://github.com/SuddenlyHazel/dfinity-million-dollar-homepage"
+
+[[repo]]
+url = "https://github.com/SuddenlyHazel/dfinity_nft"
+
+[[repo]]
+url = "https://github.com/SuddenlyHazel/dfinity-streams"
+
+[[repo]]
+url = "https://github.com/SuddenlyHazel/DIP721"
+
+[[repo]]
+url = "https://github.com/SuddenlyHazel/ic_vue_identity"
+
+[[repo]]
+url = "https://github.com/SuddenlyHazel/wasm_in_the_wasm"
+
+[[repo]]
+url = "https://github.com/sudograph/sudograph"
+
+[[repo]]
+url = "https://github.com/tahublockchain/tahu"
+
+[[repo]]
+url = "https://github.com/tahublockchain/try"
+
+[[repo]]
+url = "https://github.com/tarek-eg/bariza"
+
+[[repo]]
+url = "https://github.com/tarek-eg/dkyc"
+
+[[repo]]
+url = "https://github.com/tarek-eg/ic-vote"
+
+[[repo]]
+url = "https://github.com/tarek-eg/metascore_demo_game"
+
+[[repo]]
+url = "https://github.com/taylorham/cra-template-dfx"
+
+[[repo]]
+url = "https://github.com/tglaeser/hello"
+
+[[repo]]
+url = "https://github.com/thmufl/dexpert"
+
+[[repo]]
+url = "https://github.com/timohanke/hack13"
+
+[[repo]]
+url = "https://github.com/Toniq-Labs/wrapped_cycles"
+
+[[repo]]
+url = "https://github.com/tuvs85/Blockchain-wallet"
+
+[[repo]]
+url = "https://github.com/udinnet/momento"
+
+[[repo]]
+url = "https://github.com/umeklinks/flutter_canister_app"
+
+[[repo]]
+url = "https://github.com/uney/ic-wall-testing"
+
+[[repo]]
+url = "https://github.com/vanguard88728/ic_avatar"
+
+[[repo]]
+url = "https://github.com/vanguard88728/icp_tutorial"
+
+[[repo]]
+url = "https://github.com/vartiukh/dfinity-nest-test"
+
+[[repo]]
+url = "https://github.com/vikrembhagi/vite-react-ic_starter"
+
+[[repo]]
+url = "https://github.com/warashibe/ask-hide"
+
+[[repo]]
+url = "https://github.com/wcannon/ic-basic-dependency-rust"
+
+[[repo]]
+url = "https://github.com/wcannon/ic-counter-rust"
+
+[[repo]]
+url = "https://github.com/wcannon/ic-hello-world-rust"
+
+[[repo]]
+url = "https://github.com/wcannon/ic-profile-rust"
+
+[[repo]]
+url = "https://github.com/webcoderz/webi_v3_pyodide"
+
+[[repo]]
+url = "https://github.com/webi-ai/webi_canister_api"
+
+[[repo]]
+url = "https://github.com/webi-ai/webi_frontend"
+
+[[repo]]
+url = "https://github.com/webi-ai/webi_routing_api"
+
+[[repo]]
+url = "https://github.com/wildmouse/dfinity-todo-example"
+
+[[repo]]
+url = "https://github.com/witterlee/pub_sub_dfinity"
+
+[[repo]]
+url = "https://github.com/wlchn/try-icp"
+
+[[repo]]
+url = "https://github.com/wshchqdxdxsh/icp-code"
+
+[[repo]]
+url = "https://github.com/yanbowen1994/dfinity_cdk_test"
+
+[[repo]]
+url = "https://github.com/yosadchyi/dfinity-queue"
+
+[[repo]]
+url = "https://github.com/yourkungfunogood/ic-angular-cli"
+
+[[repo]]
+url = "https://github.com/yuta17/hello-difinity"
+
+[[repo]]
+url = "https://github.com/z330789559/blockchart"
+
+[[repo]]
+url = "https://github.com/z330789559/duck"
+
+[[repo]]
+url = "https://github.com/zhangjiujiang/hello2"
+
+[[repo]]
+url = "https://github.com/zhangjiujiang/plug-demo"
+
+[[repo]]
+url = "https://github.com/zhangjiujiang/token721"
+
+[[repo]]
+url = "https://github.com/zhangjiujiang/wallet"
+


### PR DESCRIPTION
# Motivation
Someone drew my attention to crypto-ecosystems.  I too have a list of Dfinity (Internet Computer) projects, with everything from personal projects (e.g. https://github.com/andyzal/icstatica) and a canister that itself gets adoption stats (https://github.com/dprats/icp-ecosystem) to full blown projects like https://github.com/getimpactnow/getimpactnow (which has a [website](https://getimpactnow.org/) and the team is working on an app).

# Changes
This PR adds the projects I was able to find to your list.  Thank you for those on your list that I didn't have yet.

# Notes
Are there particular criteria you need a project to fulfil to be listed?  This list is suitable for general adoption but if you need only projects with thousands of users this would have to be filtered quite a bit.  Maybe we could also add project URLs, or we can try to get the live number of users for these canisters.  What do you think?  Getting live stats would require some work but could be done.  Maybe not soon, as I have a new family member about to land, but the data is all available to do so, I think, once we have domain names.