### PR TITLE
Add AshSwap to Elrond ecosystem

### DIFF
--- a/data/ecosystems/e/elrond.toml
+++ b/data/ecosystems/e/elrond.toml
@@ -561,3 +561,9 @@ url = "https://github.com/Superciety/identity-sc"
 
 [[repo]]
 url = "https://github.com/ValidWorks/validworks-contract"
+
+[[repo]]
+url = "https://github.com/ashswap/faucet"
+
+[[repo]]
+url = "https://github.com/ashswap/interface"

--- a/data/ecosystems/e/elrond.toml
+++ b/data/ecosystems/e/elrond.toml
@@ -567,3 +567,6 @@ url = "https://github.com/ashswap/faucet"
 
 [[repo]]
 url = "https://github.com/ashswap/interface"
+
+[[repo]]
+url = "https://github.com/bicarus-labs/elrond-sdk-erdrs"


### PR DESCRIPTION
Our first public product, AshSwap - a stable-swap exchange, is built on Elrond.
We already have testnet version up and running at https://testnet.ashswap.io.
The token faucet at: https://faucet.ashswap.io.
Code can be found at https://github.com/ashswap.