### PR TITLE
Update Polkadot ecosystem by adding devhub repos and ParityAsia and SubstrateCourse orgs

### DIFF
--- a/data/ecosystems/p/polkadot.toml
+++ b/data/ecosystems/p/polkadot.toml
@@ -2,8 +2,6 @@
 title = "Polkadot"
 
 sub_ecosystems = [
-  " RMRK Team",
-  " Substrate Developer Hub",
   "Acala",
   "Adoria Soft",
   "Airalab",
@@ -134,6 +132,7 @@ sub_ecosystems = [
   "Pontem Network",
   "ProChain",
   "RioDefi",
+  "RMRK Team",
   "SafePal",
   "Saito",
   "SecondState",
@@ -147,13 +146,14 @@ sub_ecosystems = [
   "Sora",
   "Spheroid Universe",
   "Stafi",
-  "Stafi protocol",
+  "Stafi Protocol",
   "SubDAO-Network",
   "Subquery",
   "Subscan",
   "Subsocial",
   "Subspace Network",
   "Subsquid",
+  "Substrate Developer Hub",
   "Sunrise Protocol",
   "Supercolony",
   "t3rn",
@@ -183,10 +183,13 @@ github_organizations = [
   "https://github.com/docknetwork",
   "https://github.com/galacticcouncil",
   "https://github.com/helikon-labs",
+  "https://github.com/parityasia",
   "https://github.com/patractlabs",
   "https://github.com/polkadot-js",
   "https://github.com/soramitsu",
   "https://github.com/subquery",
+  "https://github.com/substrate-developer-hub",
+  "https://github.com/SubstrateCourse",
   "https://github.com/vue-polkadot",
   "https://github.com/w3f",
 ]
@@ -1670,13 +1673,13 @@ url = "https://github.com/jaybutera/nft-registry"
 url = "https://github.com/jiayaoqijia/Weather-Forecast"
 
 [[repo]]
-url = "https://github.com/jimmychu0807/poe-tutorial"
+url = "https://github.com/jimmychu0807/orml-exchange"
 
 [[repo]]
-url = "https://github.com/jimmychu0807/substrate-offchain-pricefetch"
+url = "https://github.com/jimmychu0807/substrate-offchain-worker-demo"
 
 [[repo]]
-url = "https://github.com/jimmychu0807/tutorial-offchain-worker"
+url = "https://github.com/jimmychu0807/tx-submitter"
 
 [[repo]]
 url = "https://github.com/johnhuang68/substrate-node-template"
@@ -1914,10 +1917,16 @@ url = "https://github.com/PACTCare/Substrate-Web3-DNS-Tutorial"
 url = "https://github.com/parallel-finance/parallel"
 
 [[repo]]
-url = "https://github.com/ParityAsia/hackathon-2021-spring"
+url = "https://github.com/parityasia/hackathon-2021-autumn"
 
 [[repo]]
-url = "https://github.com/ParityAsia/hackathon-2021-summer"
+url = "https://github.com/parityasia/hackathon-2021-spring"
+
+[[repo]]
+url = "https://github.com/parityasia/hackathon-2021-summer"
+
+[[repo]]
+url = "https://github.com/parityasia/substrate-newsletter"
 
 [[repo]]
 url = "https://github.com/paritytech/as-substrate"
@@ -3090,13 +3099,22 @@ url = "https://github.com/subquery/vm2"
 url = "https://github.com/substrate-developer-hub/awesome-substrate"
 
 [[repo]]
-url = "https://github.com/substrate-developer-hub/cumulus-workshop"
+url = "https://github.com/substrate-developer-hub/frontier-node-template"
+
+[[repo]]
+url = "https://github.com/substrate-developer-hub/hackathon-knowledge-map"
+
+[[repo]]
+url = "https://github.com/substrate-developer-hub/migration-example"
 
 [[repo]]
 url = "https://github.com/substrate-developer-hub/pallet-did"
 
 [[repo]]
-url = "https://github.com/substrate-developer-hub/recipes"
+url = "https://github.com/substrate-developer-hub/substrate-developer-hub.github.io"
+
+[[repo]]
+url = "https://github.com/substrate-developer-hub/substrate-docs"
 
 [[repo]]
 url = "https://github.com/substrate-developer-hub/substrate-front-end-template"
@@ -3105,10 +3123,16 @@ url = "https://github.com/substrate-developer-hub/substrate-front-end-template"
 url = "https://github.com/substrate-developer-hub/substrate-node-template"
 
 [[repo]]
+url = "https://github.com/substrate-developer-hub/substrate-parachain-template"
+
+[[repo]]
 url = "https://github.com/substrate-developer-hub/substrate-proof-of-existence"
 
 [[repo]]
-url = "https://github.com/substrate-developer-hub/tcr-substrate"
+url = "https://github.com/substrate-developer-hub/utxo-workshop"
+
+[[repo]]
+url = "https://github.com/SubstrateCourse/slides"
 
 [[repo]]
 url = "https://github.com/SubstrateCourse-Term3/BitDAO"

--- a/data/ecosystems/p/polkadot.toml
+++ b/data/ecosystems/p/polkadot.toml
@@ -3126,12 +3126,6 @@ url = "https://github.com/substrate-developer-hub/substrate-node-template"
 url = "https://github.com/substrate-developer-hub/substrate-parachain-template"
 
 [[repo]]
-url = "https://github.com/substrate-developer-hub/substrate-proof-of-existence"
-
-[[repo]]
-url = "https://github.com/substrate-developer-hub/utxo-workshop"
-
-[[repo]]
 url = "https://github.com/SubstrateCourse/slides"
 
 [[repo]]


### PR DESCRIPTION
I am updating Polkadot ecosystem:

- removing from @substrate-developer-hub org what are no longer there or maintained and adding new repos.
- adding two orgs: @parityasia, and @SubstrateCourse orgs. The first one being used by Parity Asia team, and the second one for maintaining Substrate course related codes and assets.

cc Parity team: @sacha-l @NukeManDan @helenajwang @SuragSheth @SBalaguer

@jubos, thank for reviewing and let me know if there is any concern with this PR.