### PR TITLE
Update hedera-hashgraph.toml

### DIFF
--- a/data/ecosystems/h/hedera-hashgraph.toml
+++ b/data/ecosystems/h/hedera-hashgraph.toml
@@ -1,11 +1,15 @@
 # Ecosystem Level Information
-title = "Hedera Hashgraph"
+title = "Hedera"
 
-sub_ecosystems = []
+sub_ecosystems = ["SaucerSwap"]
 
 github_organizations = ["https://github.com/hashgraph"]
 
 # Repositories
+[[repo]]
+url = "https://github.com/saucerswaplabs/saucerswaplabs-core"
+tags = ["Dapp"]
+
 [[repo]]
 url = "https://github.com/hashgraph/.github"
 


### PR DESCRIPTION
Updated to include SaucerSwap being built on Hedera and update to the name from "Hedera Hashgraph" to the officially recognized name "Hedera".