### PR TITLE
Add 2 Tezos organizations and main repositories

### DIFF
--- a/data/ecosystems/l/ligolang.toml
+++ b/data/ecosystems/l/ligolang.toml
@@ -1,0 +1,31 @@
+# Ecosystem Level Information
+title = "Ligolang"
+
+sub_ecosystems = []
+
+github_organizations = ["https://github.com/ligolang"]
+
+# Repositories
+[[repo]]
+url = "https://github.com/ligolang/bigarray-cameligo"
+
+[[repo]]
+url = "https://github.com/ligolang/contract-catalogue"
+
+[[repo]]
+url = "https://github.com/ligolang/dao-cameligo"
+
+[[repo]]
+url = "https://github.com/ligolang/ligo-mirror"
+
+[[repo]]
+url = "https://github.com/ligolang/math-lib-cameligo"
+
+[[repo]]
+url = "https://github.com/ligolang/multisig-cameligo"
+
+[[repo]]
+url = "https://github.com/ligolang/permit-cameligo"
+
+[[repo]]
+url = "https://github.com/ligolang/registry"

--- a/data/ecosystems/m/marigold.toml
+++ b/data/ecosystems/m/marigold.toml
@@ -7,12 +7,6 @@ github_organizations = ["https://github.com/marigold-dev"]
 
 # Repositories
 [[repo]]
-url = "https://github.com/marigold-dev/auditor"
-
-[[repo]]
-url = "https://github.com/marigold-dev/batcher"
-
-[[repo]]
 url = "https://github.com/marigold-dev/decookies"
 
 [[repo]]

--- a/data/ecosystems/m/marigold.toml
+++ b/data/ecosystems/m/marigold.toml
@@ -1,0 +1,25 @@
+# Ecosystem Level Information
+title = "Marigold"
+
+sub_ecosystems = []
+
+github_organizations = ["https://github.com/marigold-dev"]
+
+# Repositories
+[[repo]]
+url = "https://github.com/marigold-dev/auditor"
+
+[[repo]]
+url = "https://github.com/marigold-dev/batcher"
+
+[[repo]]
+url = "https://github.com/marigold-dev/decookies"
+
+[[repo]]
+url = "https://github.com/marigold-dev/deku"
+
+[[repo]]
+url = "https://github.com/marigold-dev/tzportal"
+
+[[repo]]
+url = "https://github.com/marigold-dev/tuna"

--- a/data/ecosystems/t/tezos.toml
+++ b/data/ecosystems/t/tezos.toml
@@ -1238,12 +1238,6 @@ url = "https://github.com/madhavaggar/subscription-token"
 url = "https://github.com/madhavaggar/Tezos-P2P-Lending"
 
 [[repo]]
-url = "https://github.com/marigold-dev/auditor"
-
-[[repo]]
-url = "https://github.com/marigold-dev/batcher"
-
-[[repo]]
 url = "https://github.com/marigold-dev/decookies"
 
 [[repo]]

--- a/data/ecosystems/t/tezos.toml
+++ b/data/ecosystems/t/tezos.toml
@@ -13,6 +13,7 @@ sub_ecosystems = [
   "Kolibri Finance",
   "Kukai Wallet",
   "Madfish Solutions",
+  "Marigold",
   "Paul Token",
   "Plenty Defi",
   "Quipuswap",
@@ -31,6 +32,7 @@ github_organizations = [
   "https://github.com/cryptiumlabs",
   "https://github.com/hicetnunc2000",
   "https://github.com/kukai-wallet",
+  "https://github.com/marigold-dev/",
   "https://github.com/simplestaking",
   "https://github.com/tacoinfra",
   "https://github.com/tezbox",
@@ -1218,7 +1220,22 @@ url = "https://github.com/madhavaggar/subscription-token"
 url = "https://github.com/madhavaggar/Tezos-P2P-Lending"
 
 [[repo]]
+url = "https://github.com/marigold-dev/auditor"
+
+[[repo]]
+url = "https://github.com/marigold-dev/batcher"
+
+[[repo]]
+url = "https://github.com/marigold-dev/decookies"
+
+[[repo]]
 url = "https://github.com/marigold-dev/deku"
+
+[[repo]]
+url = "https://github.com/marigold-dev/tzportal"
+
+[[repo]]
+url = "https://github.com/marigold-dev/tuna"
 
 [[repo]]
 url = "https://github.com/mathMakesArt/ArtContracts"

--- a/data/ecosystems/t/tezos.toml
+++ b/data/ecosystems/t/tezos.toml
@@ -1121,7 +1121,28 @@ url = "https://github.com/lattejed/tezos-azure-hsm-signer"
 url = "https://github.com/leepuff/tzs-app"
 
 [[repo]]
+url = "https://github.com/ligolang/bigarray-cameligo"
+
+[[repo]]
+url = "https://github.com/ligolang/contract-catalogue"
+
+[[repo]]
+url = "https://github.com/ligolang/dao-cameligo"
+
+[[repo]]
 url = "https://github.com/ligolang/ligo-mirror"
+
+[[repo]]
+url = "https://github.com/ligolang/math-lib-cameligo"
+
+[[repo]]
+url = "https://github.com/ligolang/multisig-cameligo"
+
+[[repo]]
+url = "https://github.com/ligolang/permit-cameligo"
+
+[[repo]]
+url = "https://github.com/ligolang/registry"
 
 [[repo]]
 url = "https://github.com/LordDarkHelmet/TezosPassordCrackerForWindows"

--- a/data/ecosystems/t/tezos.toml
+++ b/data/ecosystems/t/tezos.toml
@@ -530,9 +530,6 @@ url = "https://github.com/Cryptonomic/Tezos-Micheline-to-Michelson-Conversion"
 url = "https://github.com/csoreff/taquito-boilerplate"
 
 [[repo]]
-url = "https://github.com/d4hines/marigold-tezos"
-
-[[repo]]
 url = "https://github.com/dakk/FreeBSD-vagrant-tezos"
 
 [[repo]]


### PR DESCRIPTION
Hi!

This PR adds two Tezos organizations, Marigold and Ligolang, and removes a collaborator's mirror of a Gitlab repository that is already listed elsewhere.