### PR TITLE
Update stacks.toml with final batch of urls

### DIFF
--- a/data/ecosystems/s/stacks.toml
+++ b/data/ecosystems/s/stacks.toml
@@ -3655,3 +3655,114 @@ url = "https://github.com/yknl/publik"
 
 [[repo]]
 url = "https://github.com/yknl/stacks.js"
+
+[[repo]]
+url = "https://github.com/loganlenz"
+
+[[repo]]
+url = "https://github.com/tuanphungcz/linkstacks.vercel.app"
+
+[[repo]]
+url = "https://github.com/Sun-djata/postmessages"
+
+[[repo]]
+url = "https://github.com/priyanshu-678/StackAgent"
+
+[[repo]]
+url = "https://github.com/djs-1001/clarity-counter"
+
+[[repo]]
+url = "https://github.com/exp0nge/stacks-bodega-cat"
+
+[[repo]]
+url = "https://github.com/dpericich/Hiro-Stackathon-NFT-ABCs"
+
+[[repo]]
+url = "https://github.com/Oyeins-GUI/nft"
+
+[[repo]]
+url = "https://github.com/Oyeins-GUI/Counter-dApp"
+
+[[repo]]
+url = "https://github.com/Sun-djata/blockpost"
+
+[[repo]]
+url = "https://github.com/MikeSpa/dex-on-stacks"
+
+[[repo]]
+url = "https://github.com/yanukadeneth99/Deeds"
+
+[[repo]]
+url = "https://github.com/Sun-djata/MegaRewards"
+
+[[repo]]
+url = "https://github.com/Sun-djata/nft-mint-multiple"
+
+[[repo]]
+url = "https://github.com/Sun-djata/the-final-counter"
+
+[[repo]]
+url = "https://github.com/DemocracyStudio/simple-counter"
+
+[[repo]]
+url = "https://github.com/priyanshu-678/Sinecure"
+
+[[repo]]
+url = "https://github.com/DemocracyStudio/landminis3_marketplace"
+
+[[repo]]
+url = "https://github.com/DemocracyStudio/warsaw-coliving"
+
+[[repo]]
+url = "https://github.com/virajmane/HiroTransactionVerifier"
+
+[[repo]]
+url = "https://github.com/amahajan87/countered"
+
+[[repo]]
+url = "https://github.com/amahajan87/InteractWithClarity"
+
+[[repo]]
+url = "https://github.com/proiacm/kudos"
+
+[[repo]]
+url = "https://github.com/dpericich/Hiro-Hackathon-Counter"
+
+[[repo]]
+url = "https://github.com/yanukadeneth99/NFT-Tokens"
+
+[[repo]]
+url = "https://github.com/utkarsh23/stacker-squares/tree/master/clarity"
+
+[[repo]]
+url = "https://github.com/utkarsh23/stacker-squares/tree/master/frontend"
+
+[[repo]]
+url = "https://github.com/yanukadeneth99/Counter"
+
+[[repo]]
+url = "https://github.com/Viclinh/ClarNFT"
+
+[[repo]]
+url = "https://github.com/khoa-nvk/desplitly"
+
+[[repo]]
+url = "https://github.com/DemocracyStudio/landminis3_marketplace"
+
+[[repo]]
+url = "https://github.com/Sun-djata/MegaRewards"
+
+[[repo]]
+url = "https://github.com/Zeus-Adin/Clarity-Hackerton"
+
+[[repo]]
+url = "https://github.com/thecodizt/ClarityProjects"
+
+[[repo]]
+url = "https://github.com/hatskier/synths-on-stacks"
+
+[[repo]]
+url = "https://github.com/options-vault/options-vault"
+
+[[repo]]
+url = "https://github.com/yanukadeneth99/Deeds"


### PR DESCRIPTION
Appending one final batch of Stacks-related development repositories to be included in the 2022 EC report. We had one last crop of github submissions to two hackathons that we would request be included in ecosystem metrics.