### PR TITLE
Update and rename hedera-hashgraph.toml to hedera.toml

### DIFF
--- a/data/ecosystems/h/hedera.toml
+++ b/data/ecosystems/h/hedera.toml
@@ -1,7 +1,10 @@
 # Ecosystem Level Information
-title = "Hedera Hashgraph"
+title = "Hedera"
 
-sub_ecosystems = []
+sub_ecosystems = [
+  " Calaxy",
+  " Limechain",
+  ]
 
 github_organizations = ["https://github.com/hashgraph"]
 


### PR DESCRIPTION
Updating the hedera-hashgraph.toml file name to instead be hedera.toml (official name) and the addition of two sub-ecosystems (Calaxy & Limechain).

In this pull request, I added Calaxy as an ecosystem in the appropriate section: https://github.com/electric-capital/crypto-ecosystems/pull/270

Please let me know if all of the above was done correctly; if so, I'm going to continue using the same approach to add additional sub-ecosystems to Hedera and create more ecosystems (adding files) for projects like Calaxy.

Thank you