### PR TITLE
remove old / moved / hidden Axelar repositories

### DIFF
--- a/data/ecosystems/a/axelar-network.toml
+++ b/data/ecosystems/a/axelar-network.toml
@@ -13,9 +13,6 @@ url = "https://github.com/axelarnetwork/audits"
 url = "https://github.com/axelarnetwork/axelar-cgp-aptos"
 
 [[repo]]
-url = "https://github.com/axelarnetwork/axelar-cgp-move"
-
-[[repo]]
 url = "https://github.com/axelarnetwork/axelar-cgp-solidity"
 
 [[repo]]
@@ -28,9 +25,6 @@ url = "https://github.com/axelarnetwork/axelar-dapp-starter-kit"
 url = "https://github.com/axelarnetwork/axelar-docs"
 
 [[repo]]
-url = "https://github.com/axelarnetwork/axelar-gateway-sample"
-
-[[repo]]
 url = "https://github.com/axelarnetwork/axelar-gmp-sample"
 
 [[repo]]
@@ -40,19 +34,10 @@ url = "https://github.com/axelarnetwork/axelar-gmp-sdk-solidity"
 url = "https://github.com/axelarnetwork/axelar-local-dev"
 
 [[repo]]
-url = "https://github.com/axelarnetwork/axelar-local-dev-sample"
-
-[[repo]]
-url = "https://github.com/axelarnetwork/axelar-local-gateway"
-
-[[repo]]
 url = "https://github.com/axelarnetwork/axelar-local-gmp-examples"
 
 [[repo]]
 url = "https://github.com/axelarnetwork/axelar-signing-relayer"
-
-[[repo]]
-url = "https://github.com/axelarnetwork/axelar-utils-solidity"
 
 [[repo]]
 url = "https://github.com/axelarnetwork/axelar-web-app"
@@ -103,18 +88,6 @@ url = "https://github.com/axelarnetwork/deposit-address-demo"
 url = "https://github.com/axelarnetwork/evm-cosmos-gmp-sample"
 
 [[repo]]
-url = "https://github.com/axelarnetwork/gmp-api"
-
-[[repo]]
-url = "https://github.com/axelarnetwork/gmp-caching-aws"
-
-[[repo]]
-url = "https://github.com/axelarnetwork/gmp-caching-docker"
-
-[[repo]]
-url = "https://github.com/axelarnetwork/gmp-caching-nodejs"
-
-[[repo]]
 url = "https://github.com/axelarnetwork/gmp-crawler"
 
 [[repo]]
@@ -145,9 +118,6 @@ url = "https://github.com/axelarnetwork/sdk-demo-v5-deposit-address"
 url = "https://github.com/axelarnetwork/sentinel"
 
 [[repo]]
-url = "https://github.com/axelarnetwork/solidity-cgp-gateway"
-
-[[repo]]
 url = "https://github.com/axelarnetwork/terraform-aws-eks"
 
 [[repo]]
@@ -164,9 +134,6 @@ url = "https://github.com/axelarnetwork/tofnd"
 
 [[repo]]
 url = "https://github.com/axelarnetwork/token-linker"
-
-[[repo]]
-url = "https://github.com/axelarnetwork/token-linker-example"
 
 [[repo]]
 url = "https://github.com/axelarnetwork/unknown_order"


### PR DESCRIPTION
This PR removes repositories that are no longer public or have been moved within the `axelarnetwork` GitHub organization.

**NOTE:** I'm not sure how the electric-capital system works. If these need to be here to pull data from earlier in 2022, feel free to reject this PR as these USED to be valid repositories.