### PR TITLE
Add missing repos to tezos.toml

### DIFF
--- a/data/ecosystems/t/tezos.toml
+++ b/data/ecosystems/t/tezos.toml
@@ -2439,6 +2439,15 @@ url = "https://gitlab.com/camlcase-dev/tezos-rpc-postman"
 url = "https://gitlab.com/camlcase-dev/tzpay-dexter"
 
 [[repo]]
+url = "https://gitlab.com/coexya/tezos/tezos-digisign"
+
+[[repo]]
+url = "https://gitlab.com/dailambda/plebeia"
+
+[[repo]]
+url = "https://gitlab.com/equisafe/nyx"
+
+[[repo]]
 url = "https://gitlab.com/et4te/igloo"
 
 [[repo]]
@@ -2446,6 +2455,9 @@ url = "https://gitlab.com/et4te/ocaml-hacl"
 
 [[repo]]
 url = "https://gitlab.com/et4te/tezos-tendermint"
+
+[[repo]]
+url = "https://gitlab.com/formal-land/coq-tezos-of-ocaml"
 
 [[repo]]
 url = "https://gitlab.com/ligolang/ligo"
@@ -2562,6 +2574,9 @@ url = "https://gitlab.com/nomadic-labs/teztool"
 
 [[repo]]
 url = "https://gitlab.com/nomadic-labs/training.nomadic-labs.com"
+
+[[repo]]
+url = "https://gitlab.com/nomadic-labs-free-resources/eurotz-euro-stable-coin"
 
 [[repo]]
 url = "https://gitlab.com/nomadic-labs/try-michelson"


### PR DESCRIPTION
Adding missing repositories:

- https://gitlab.com/coexya/tezos/tezos-digisign
- https://gitlab.com/dailambda/plebeia
- https://gitlab.com/equisafe/nyx
- https://gitlab.com/formal-land/coq-tezos-of-ocaml
- https://gitlab.com/nomadic-labs-free-resources/eurotz-euro-stable-coin