### PR TITLE
Tezos: add missing gitlab.com/tezos and gitlab.com/nomadic-labs repositories 

### DIFF
--- a/data/ecosystems/t/tezos.toml
+++ b/data/ecosystems/t/tezos.toml
@@ -1061,6 +1061,7 @@ url = "https://github.com/juster-finance/juster-app"
 
 [[repo]]
 url = "https://github.com/juztin/flextesa-easybake"
+tags = ["Testing", "Testnet", "Infrastructure"]
 
 [[repo]]
 url = "https://github.com/juztin/pytezos"
@@ -1326,6 +1327,7 @@ url = "https://github.com/maxtez-raspbaker/tezos-rpi3"
 
 [[repo]]
 url = "https://github.com/mblockelet/opentezos"
+tags = ["Documentation"]
 
 [[repo]]
 url = "https://github.com/mcwithimp/tezos-quickstart"
@@ -1452,6 +1454,7 @@ url = "https://github.com/OCamlPro/tzscan"
 
 [[repo]]
 url = "https://github.com/octo-technology/OpenTezos"
+tags = ["Documentation"]
 
 [[repo]]
 url = "https://github.com/octo-technology/tezos-academy"
@@ -2385,6 +2388,9 @@ url = "https://github.com/zastrin/tezos-voting-dapp"
 url = "https://github.com/Zondax/ledger-tezos"
 
 [[repo]]
+url = "https://gitlab.com/MBourgoin/octez-rpc-web-server"
+
+[[repo]]
 url = "https://gitlab.com/camlcase-dev/bs-tezos"
 
 [[repo]]
@@ -2446,9 +2452,13 @@ url = "https://gitlab.com/et4te/igloo"
 
 [[repo]]
 url = "https://gitlab.com/et4te/ocaml-hacl"
+tags = ["Developer Tools", "Formal Verification", "Library"]
 
 [[repo]]
 url = "https://gitlab.com/et4te/tezos-tendermint"
+
+[[repo]]
+url = "https://gitlab.com/Killian-Delarue/octez-testnets-scripts"
 
 [[repo]]
 url = "https://gitlab.com/ligolang/ligo"
@@ -2491,18 +2501,23 @@ url = "https://gitlab.com/metastatedev/tezos"
 
 [[repo]]
 url = "https://gitlab.com/nomadic-labs/albert"
+tags = ["Developer Tools", "Library", "Formal Methods"]
 
 [[repo]]
 url = "https://gitlab.com/nomadic-labs/albert-lang.io"
+tags = ["Website"]
 
 [[repo]]
 url = "https://gitlab.com/nomadic-labs/ansible-tezos-source-role"
+tags = ["DevOps"]
 
 [[repo]]
 url = "https://gitlab.com/nomadic-labs/ansible-tezos-source-run-role"
+tags = ["DevOps"]
 
 [[repo]]
 url = "https://gitlab.com/nomadic-labs/coq-tezos-of-ocaml"
+tags = ["Developer Tools", "Formal Verification"]
 
 [[repo]]
 url = "https://gitlab.com/nomadic-labs/cortez-android"
@@ -2513,25 +2528,43 @@ url = "https://gitlab.com/nomadic-labs/cortez-ios"
 tags = ["Wallet"]
 
 [[repo]]
+url = "https://gitlab.com/nomadic-labs/data-encoding"
+tags = ["Library"]
+
+[[repo]]
 url = "https://gitlab.com/nomadic-labs/emmy-simulator"
+tags = ["Developer Tools"]
 
 [[repo]]
 url = "https://gitlab.com/nomadic-labs/emmyplus-experiments"
+tags = ["Developer Tools"]
 
 [[repo]]
 url = "https://gitlab.com/nomadic-labs/grafazos"
+tags = ["Developer Tools", "Analysis"]
 
 [[repo]]
 url = "https://gitlab.com/nomadic-labs/mezos"
 
 [[repo]]
 url = "https://gitlab.com/nomadic-labs/mi-cho-coq"
+tags = ["Developer Tools", "Library", "Formal Verification"]
 
 [[repo]]
 url = "https://gitlab.com/nomadic-labs/monitoring-playbooks"
+tags = ["DevOps", "Infrastructure"]
+
+[[repo]]
+url = "https://gitlab.com/nomadic-labs/ringo"
+tags = ["Library"]
+
+[[repo]]
+url = "https://gitlab.com/nomadic-labs/seqes"
+tags = ["Library"]
 
 [[repo]]
 url = "https://gitlab.com/nomadic-labs/sapling-verification"
+tags = ["Formal Verification"]
 
 [[repo]]
 url = "https://gitlab.com/nomadic-labs/smart-contracts"
@@ -2541,6 +2574,7 @@ url = "https://gitlab.com/nomadic-labs/stuck-node-alarm"
 
 [[repo]]
 url = "https://gitlab.com/nomadic-labs/tezos"
+tags = ["Protocol"]
 
 [[repo]]
 url = "https://gitlab.com/nomadic-labs/tezos-dapp-demo"
@@ -2561,6 +2595,14 @@ url = "https://gitlab.com/nomadic-labs/tezos-metrics"
 url = "https://gitlab.com/nomadic-labs/tezos-protocols"
 
 [[repo]]
+url = "https://gitlab.com/nomadic-labs/tezt"
+tags = ["Testing", "Developer Tools"]
+
+[[repo]]
+url = "https://gitlab.com/nomadic-labs/teztale"
+tags = ["Developer Tools", "Analysis"]
+
+[[repo]]
 url = "https://gitlab.com/nomadic-labs/teztool"
 
 [[repo]]
@@ -2570,7 +2612,80 @@ url = "https://gitlab.com/nomadic-labs/training.nomadic-labs.com"
 url = "https://gitlab.com/nomadic-labs/try-michelson"
 
 [[repo]]
+url = "https://gitlab.com/nomadic-labs/cryptography/hacl-benchmark"
+tags = ["Developer Tools", "Formal Verification"]
+
+[[repo]]
+url = "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381"
+tags = ["Library"]
+
+[[repo]]
+url = "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash"
+tags = ["Library"]
+
+[[repo]]
+url = "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-signature"
+tags = ["Library"]
+
+[[repo]]
+url = "https://gitlab.com/nomadic-labs/cryptography/ocaml-chia-vdf"
+tags = ["Library"]
+
+[[repo]]
+url = "https://gitlab.com/nomadic-labs/cryptography/distributed"
+tags = ["Library"]
+
+[[repo]]
+url = "https://gitlab.com/nomadic-labs/cryptography/ocaml-ec"
+tags = ["Library"]
+
+[[repo]]
+url = "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff"
+tags = ["Library"]
+
+[[repo]]
+url = "https://gitlab.com/nomadic-labs/cryptography/ocaml-polynomial"
+tags = ["Library"]
+
+[[repo]]
+url = "https://gitlab.com/nomadic-labs/cryptography/privacy-team"
+tags = ["Library"]
+
+[[repo]]
+url = "https://gitlab.com/nomadic-labs/umami-wallet/graphic-proxy"
+tags = ["Developer Tools"]
+
+[[repo]]
+url = "https://gitlab.com/nomadic-labs/umami-wallet/testruns"
+tags = ["Developer Tools"]
+
+[[repo]]
+url = "https://gitlab.com/nomadic-labs/umami-wallet/umami"
+tags = ["Wallet"]
+
+[[repo]]
+url = "https://gitlab.com/nomadic-labs/umami-wallet/umami-mobile"
+tags = ["Wallet"]
+
+[[repo]]
+url = "https://gitlab.com/nomadic-labs/umami-wallet/umami-stack-orchestration"
+tags = ["Wallet", "Infrastructure", "DevOps"]
+
+[[repo]]
+url = "https://gitlab.com/nomadic-labs-free-resources/claimz"
+tags = ["Contracts"]
+
+[[repo]]
+url = "https://gitlab.com/nomadic-labs-free-resources/opentezos"
+tags = ["Documentation"]
+
+[[repo]]
+url = "https://gitlab.com/nomadic-labs-free-resources/tzsign"
+tags = ["Developer Tools"]
+
+[[repo]]
 url = "https://gitlab.com/obsidian.systems/flextesa-extras"
+tags = ["Testing", "Testnet", "Infrastructure"]
 
 [[repo]]
 url = "https://gitlab.com/obsidian.systems/tezos-bake-monitor"
@@ -2594,6 +2709,45 @@ url = "https://gitlab.com/polychainlabs/tezos-hsm-signer"
 url = "https://gitlab.com/polychainlabs/tezos-network-monitor"
 
 [[repo]]
+url = "https://gitlab.com/tezos/cortez-android"
+tags = ["Wallet"]
+
+[[repo]]
+url = "https://gitlab.com/tezos/flextesa"
+tags = ["Testing", "Testnet", "Infrastructure"]
+
+[[repo]]
+url = "https://gitlab.com/tezos/michelson-reference"
+
+[[repo]]
+url = "https://gitlab.com/tezos/opam-repository"
+
+[[repo]]
+url = "https://gitlab.com/tezos/tezos"
+tags = ["Protocol"]
+
+[[repo]]
+url = "https://gitlab.com/tezos/tezos-faucet"
+
+[[repo]]
+url = "https://gitlab.com/tezos/tezos.gitlab.io"
+tags = ["Documentation"]
+
+[[repo]]
+url = "https://gitlab.com/tezos/kernel"
+
+[[repo]]
+url = "https://gitlab.com/tezos/tezos-rust-libs"
+
+[[repo]]
+url = "https://gitlab.com/tezos/tzip"
+tags = ["RFC", "Standards"]
+
+[[repo]]
+url = "https://gitlab.com/tzip/tzip"
+tags = ["RFC", "Standards"]
+
+[[repo]]
 url = "https://gitlab.com/tezos-domains/app"
 
 [[repo]]
@@ -2612,33 +2766,8 @@ url = "https://gitlab.com/tezos-domains/indexer"
 url = "https://gitlab.com/tezos-kiln/kiln"
 
 [[repo]]
-url = "https://gitlab.com/tezos/cortez-android"
-tags = ["Wallet"]
-
-[[repo]]
-url = "https://gitlab.com/tezos/flextesa"
-
-[[repo]]
-url = "https://gitlab.com/tezos/michelson-reference"
-
-[[repo]]
-url = "https://gitlab.com/tezos/opam-repository"
-
-[[repo]]
-url = "https://gitlab.com/tezos/tezos"
-tags = ["Protocol"]
-
-[[repo]]
-url = "https://gitlab.com/tezos/tezos-faucet"
-
-[[repo]]
-url = "https://gitlab.com/tezos/tezos.gitlab.io"
-
-[[repo]]
-url = "https://gitlab.com/tzip/tzip"
-
-[[repo]]
 url = "https://gitlab.com/witoff/key-encoder"
 
 [[repo]]
 url = "https://gitlab.com/witoff/tezos-hsm-signer"
+


### PR DESCRIPTION
Adds several missing infra, libraries, dev tools, spec, wallets repos for Tezos - from Tezos, Nomadic Labs, Umami, and others Gitlab organizations.

Also, liberally updated some tags