### PR TITLE
Update chia.toml - add smart farm

### DIFF
--- a/data/ecosystems/c/chia.toml
+++ b/data/ecosystems/c/chia.toml
@@ -985,6 +985,9 @@ url = "https://github.com/Scribbd/tropical-chia"
 url = "https://github.com/scrutinously/chia-scripts"
 
 [[repo]]
+url = "https://github.com/scrutinously/smart-farm"
+
+[[repo]]
 url = "https://github.com/sengexyz/EzPlotter"
 
 [[repo]]


### PR DESCRIPTION
While not directly tied to the crypto, this repo is for automating the monitoring of hard drive health and temperatures, which is useful for farming Chia.