### PR TITLE
Add 254 additional Chia repos tracked from dev.chialinks.com

### DIFF
--- a/data/ecosystems/c/chia.toml
+++ b/data/ecosystems/c/chia.toml
@@ -1241,3 +1241,764 @@ url = "https://github.com/farmerdiamonds/chia-walletbalance-nodejs"
 
 [[repo]]
 url = "https://github.com/bringyour/go-xch"
+
+https://github.com/FireAcademy/golden-gate"
+
+[[repo]]
+url = "https://github.com/MaximEdogawa/seedener"
+
+[[repo]]
+url = "https://github.com/distoration/chia-network-MY-WEBSITE"
+
+[[repo]]
+url = "https://github.com/steppsr/xd-nft-wizard"
+
+[[repo]]
+url = "https://github.com/AbandonedLand/PSChiaRPC"
+
+[[repo]]
+url = "https://github.com/steppsr/droid_name_generator"
+
+[[repo]]
+url = "https://github.com/KryptomineCH/Chia-Client-API"
+
+[[repo]]
+url = "https://github.com/FireAcademy/beta-syncer"
+
+[[repo]]
+url = "https://github.com/SutuLabs/Pawket"
+
+[[repo]]
+url = "https://github.com/steppsr/norby_name_generator"
+
+[[repo]]
+url = "https://github.com/steppsr/random_name_picker"
+
+[[repo]]
+url = "https://github.com/FireAcademy/docs-fireacademy-io"
+
+[[repo]]
+url = "https://github.com/FireAcademy/fireacademy-io"
+
+[[repo]]
+url = "https://github.com/FireAcademy/dashboard-freacademy-io"
+
+[[repo]]
+url = "https://github.com/FireAcademy/fireacademy-k8s-plusplus"
+
+[[repo]]
+url = "https://github.com/FireAcademy/catchpole"
+
+[[repo]]
+url = "https://github.com/hashgreen/hoogii-wallet"
+
+[[repo]]
+url = "https://github.com/Tail-Database/tail-database-r2-uploader"
+
+[[repo]]
+url = "https://github.com/Tail-Database/tail-database-terraform"
+
+[[repo]]
+url = "https://github.com/Tail-Database/tail-database-exporter"
+
+[[repo]]
+url = "https://github.com/Tail-Database/tail-database-ui"
+
+[[repo]]
+url = "https://github.com/NFTr/nft_scripts"
+
+[[repo]]
+url = "https://github.com/Tail-Database/tail-database-client"
+
+[[repo]]
+url = "https://github.com/yyolk/dexie.py"
+
+[[repo]]
+url = "https://github.com/Tail-Database/tail-database-api"
+
+[[repo]]
+url = "https://github.com/steppsr/MyNFTIDs"
+
+[[repo]]
+url = "https://github.com/Hack-Light/HNGi9-CSV-Task"
+
+[[repo]]
+url = "https://github.com/geraldneale/chia-nft-add_uris"
+
+[[repo]]
+url = "https://github.com/Tail-Database/tail-database-app"
+
+[[repo]]
+url = "https://github.com/steppsr/GetNFTNamesFromNFTIDs"
+
+[[repo]]
+url = "https://github.com/steppsr/GetNFTIDsFromCollection"
+
+[[repo]]
+url = "https://github.com/steppsr/OwnerWalletsFromNFTIDs"
+
+[[repo]]
+url = "https://github.com/WarutaShinken/flora-barebone"
+
+[[repo]]
+url = "https://github.com/cameroncooper/sublime-chialisp"
+
+[[repo]]
+url = "https://github.com/joshpainter/budibase-datasource-chia-full-node-rpc"
+
+[[repo]]
+url = "https://github.com/Jahorse/chiabook"
+
+[[repo]]
+url = "https://github.com/hpool-in/chia-plotter"
+
+[[repo]]
+url = "https://github.com/hpool-in/chia-miner"
+
+[[repo]]
+url = "https://github.com/hpool-in/chiapp-miner"
+
+[[repo]]
+url = "https://github.com/areliszxz/Bash_madMAx43v3r_chia"
+
+[[repo]]
+url = "https://github.com/NFTr/mintr-web"
+
+[[repo]]
+url = "https://github.com/Ev4Nou4/MINTFILES-Chialisp-"
+
+[[repo]]
+url = "https://github.com/Valeri4n/Chia-Farm-Tools"
+
+[[repo]]
+url = "https://github.com/hashgreen/helm-charts"
+
+[[repo]]
+url = "https://github.com/TaichiaDao/Taichia-Chialisp"
+
+[[repo]]
+url = "https://github.com/rocketeeer/chialisp-testing"
+
+[[repo]]
+url = "https://github.com/roybotbot/roybotNFT-Minter"
+
+[[repo]]
+url = "https://github.com/hasDID-io/chia-nft"
+
+[[repo]]
+url = "https://github.com/chiameh/chia-blockchain-exporter"
+
+[[repo]]
+url = "https://github.com/0xChunk/chiaNFTScripts"
+
+[[repo]]
+url = "https://github.com/imagenaria/nftutil"
+
+[[repo]]
+url = "https://github.com/bitruss/chia-db"
+
+[[repo]]
+url = "https://github.com/steppsr/exif2metadata-proofofconcept"
+
+[[repo]]
+url = "https://github.com/steppsr/nftstorage-proofofconcept"
+
+[[repo]]
+url = "https://github.com/trgarrett/chialisp"
+
+[[repo]]
+url = "https://github.com/13thProgression/capital-blockchain"
+
+[[repo]]
+url = "https://github.com/ageorge95/seno-blockchain_BAREBONE_v1.4.0"
+
+[[repo]]
+url = "https://github.com/ageorge95/lucky-blockchain_BAREBONE_v1.4.0"
+
+[[repo]]
+url = "https://github.com/mintgarden-io/mintgarden-studio"
+
+[[repo]]
+url = "https://github.com/RudolfAchter/ChiaShell"
+
+[[repo]]
+url = "https://github.com/KryptomineCH/Chialisp-environment-preset-Windows"
+
+[[repo]]
+url = "https://github.com/NFTr/mintr-local"
+
+[[repo]]
+url = "https://github.com/maveno-de/forks-collection"
+
+[[repo]]
+url = "https://github.com/FiveFarm/FiveFarmChiaClient"
+
+[[repo]]
+url = "https://github.com/irulast/chia-simulator"
+
+[[repo]]
+url = "https://github.com/Laisho-N/CHIA"
+
+[[repo]]
+url = "https://github.com/steppsr/txch-faucet"
+
+[[repo]]
+url = "https://github.com/ColinHmrl/chia-plot-script"
+
+[[repo]]
+url = "https://github.com/UgurInanc12/project_chia"
+
+[[repo]]
+url = "https://github.com/GalactechsLLC/rust-chiapos"
+
+[[repo]]
+url = "https://github.com/igorw765/auto-plotter"
+
+[[repo]]
+url = "https://github.com/freddiecoleman/marmotcore-terraform-provider"
+
+[[repo]]
+url = "https://github.com/L4bb3rs/Chia-CAT-Breakdown"
+
+[[repo]]
+url = "https://github.com/GalactechsLLC/DruidGardenChiaPool"
+
+[[repo]]
+url = "https://github.com/GalactechsLLC/DruidGardenChiaTypes"
+
+[[repo]]
+url = "https://github.com/The-XCH-Foundation/documents"
+
+[[repo]]
+url = "https://github.com/ThebumGreg/Chia-Farm-Monitor"
+
+[[repo]]
+url = "https://github.com/baerrs/Chia_WebSocket_MQTT"
+
+[[repo]]
+url = "https://github.com/collectivenectar/chia-study"
+
+[[repo]]
+url = "https://github.com/e-nopes/chia_rpc_test"
+
+[[repo]]
+url = "https://github.com/scotopic/silo-market"
+
+[[repo]]
+url = "https://github.com/kimsk/chia-dev-challenge"
+
+[[repo]]
+url = "https://github.com/Knyllahsyhn/ChiaTempAutodel"
+
+[[repo]]
+url = "https://github.com/geoffwalmsley/clsp-template"
+
+[[repo]]
+url = "https://github.com/GalactechsLLC/rust-chia-types"
+
+[[repo]]
+url = "https://github.com/Quexington/Asset-Futures"
+
+[[repo]]
+url = "https://github.com/dmiczek-dev/chia-store"
+
+[[repo]]
+url = "https://github.com/FireAcademy/fireacademy-k8s"
+
+[[repo]]
+url = "https://github.com/cripsisxyz/chia-wallet-rpc-xch-dealer"
+
+[[repo]]
+url = "https://github.com/irulast/chia-blockchain"
+
+[[repo]]
+url = "https://github.com/GalactechsLLC/DruidGardenBase"
+
+[[repo]]
+url = "https://github.com/neurosis69/chia-sync-data"
+
+[[repo]]
+url = "https://github.com/Chia-Explorer/web-buckets"
+
+[[repo]]
+url = "https://github.com/Chia-Explorer/service-dependencies"
+
+[[repo]]
+url = "https://github.com/Chia-Explorer/networking"
+
+[[repo]]
+url = "https://github.com/Chia-Explorer/secrets"
+
+[[repo]]
+url = "https://github.com/Chia-Explorer/fargate-deployment"
+
+[[repo]]
+url = "https://github.com/Kiwihealthcare-Network/kiwi-blockchain-gui"
+
+[[repo]]
+url = "https://github.com/erdnapa/chia_helper_script"
+
+[[repo]]
+url = "https://github.com/neurosis69/chia-sync-test"
+
+[[repo]]
+url = "https://github.com/FireAcademy/fastsync-docker"
+
+[[repo]]
+url = "https://github.com/steppsr/brighttree"
+
+[[repo]]
+url = "https://github.com/Dev-Power/monitoring-chia-spacepool"
+
+[[repo]]
+url = "https://github.com/jimkoen/chialisp_playground"
+
+[[repo]]
+url = "https://github.com/amnesia106/moneymoneychia"
+
+[[repo]]
+url = "https://github.com/jcteng/chia-multiforks"
+
+[[repo]]
+url = "https://github.com/BubbleTrouble14/webserver-docker"
+
+[[repo]]
+url = "https://github.com/jfhenriques/sensormqtt"
+
+[[repo]]
+url = "https://github.com/Sukhavati-Labs/sukhavati-blockchain"
+
+[[repo]]
+url = "https://github.com/konstantin389/trade_bot"
+
+[[repo]]
+url = "https://github.com/FireAcademy/leaflet-docker"
+
+[[repo]]
+url = "https://github.com/Wes1042/Chia_shell_script"
+
+[[repo]]
+url = "https://github.com/RafaBlockDev/Chia-tutorial"
+
+[[repo]]
+url = "https://github.com/ScarFaso/plotteradmin"
+
+[[repo]]
+url = "https://github.com/cristianL0pez/cristiancoin"
+
+[[repo]]
+url = "https://github.com/ageorge95/slingSHOT-ChiaPlotTransfer"
+
+[[repo]]
+url = "https://github.com/pogacic/chia-plot-deduplicator"
+
+[[repo]]
+url = "https://github.com/strategist922/PlotMonster"
+
+[[repo]]
+url = "https://github.com/strategist922/plotManager"
+
+[[repo]]
+url = "https://github.com/Webners1/SvgNFT-Contract"
+
+[[repo]]
+url = "https://github.com/ByronAP/ChiaApi"
+
+[[repo]]
+url = "https://github.com/ytx1991/ChiaMegaMillions"
+
+[[repo]]
+url = "https://github.com/neurosis69/chia_rpc_scripts"
+
+[[repo]]
+url = "https://github.com/jack60612/chia-pool"
+
+[[repo]]
+url = "https://github.com/cangoosechain/portable-chia-workstation"
+
+[[repo]]
+url = "https://github.com/tariusagi/uchia"
+
+[[repo]]
+url = "https://github.com/100lv/teddyinstall"
+
+[[repo]]
+url = "https://github.com/Chia-Rio/Hpool-miner-autostart"
+
+[[repo]]
+url = "https://github.com/ChiaChat/chialisp-gradle-plugin"
+
+[[repo]]
+url = "https://github.com/SutuLabs/Dashboard"
+
+[[repo]]
+url = "https://github.com/LexiccLabs/SeerNet"
+
+[[repo]]
+url = "https://github.com/zodi1337/Raspberry-HDD-Mining-Projects"
+
+[[repo]]
+url = "https://github.com/technickal1/madmax-prompts"
+
+[[repo]]
+url = "https://github.com/johodh/microdot-farmsplay"
+
+[[repo]]
+url = "https://github.com/aryonp/xch"
+
+[[repo]]
+url = "https://github.com/thothloki/Chia-Plot-Transfer"
+
+[[repo]]
+url = "https://github.com/ChiaChat/kchia"
+
+[[repo]]
+url = "https://github.com/fangqiluxatu/Cn-Chia-Wiki"
+
+[[repo]]
+url = "https://github.com/VB6Hobbyst7/Plotinator-for-Chia-Blockchain"
+
+[[repo]]
+url = "https://github.com/yogahariman/My_Chia"
+
+[[repo]]
+url = "https://github.com/rabid-inventor/chialisp-examples"
+
+[[repo]]
+url = "https://github.com/aaronscientiae/GreenhouseWallet"
+
+[[repo]]
+url = "https://github.com/zolmine/roboCopy"
+
+[[repo]]
+url = "https://github.com/justas145/justas1456.github.io"
+
+[[repo]]
+url = "https://github.com/JuanThang/ChiaToolbox"
+
+[[repo]]
+url = "https://github.com/stavis-dev/chia-plots-optimizer"
+
+[[repo]]
+url = "https://github.com/taco-c/paraplot"
+
+[[repo]]
+url = "https://github.com/SugarBooty/plotalot"
+
+[[repo]]
+url = "https://github.com/hoabut/ChiaNetworkMainnetPortable"
+
+[[repo]]
+url = "https://github.com/adamz01h/madmax-powershell-replot"
+
+[[repo]]
+url = "https://github.com/OLED1/chia-manager-client"
+
+[[repo]]
+url = "https://github.com/springjools/chiacat"
+
+[[repo]]
+url = "https://github.com/jango-blockchained/chia-hpool-pp-docker"
+
+[[repo]]
+url = "https://github.com/carfloresf/plot-mover"
+
+[[repo]]
+url = "https://github.com/prozacchiwawa/vs-code-chialisp-test-adapter"
+
+[[repo]]
+url = "https://github.com/timephy/madmax-chia-plotter-manager"
+
+[[repo]]
+url = "https://github.com/koreyGambill/chia-plotter-scripts"
+
+[[repo]]
+url = "https://github.com/rHilkner/chia"
+
+[[repo]]
+url = "https://github.com/SingerJonathan/aratrum"
+
+[[repo]]
+url = "https://github.com/drakoswraith/dragonsalad"
+
+[[repo]]
+url = "https://github.com/zeddius1983/madplotter-docker"
+
+[[repo]]
+url = "https://github.com/gromran/Chia_PlotChecker"
+
+[[repo]]
+url = "https://github.com/smerchkz/chia-fast-deploy-tools"
+
+[[repo]]
+url = "https://github.com/Apool-us/Chia-Client"
+
+[[repo]]
+url = "https://github.com/icc0301/chia-plotter-zip"
+
+[[repo]]
+url = "https://github.com/icc0301/chia-plotter-inits"
+
+[[repo]]
+url = "https://github.com/prozacchiwawa/chialisp_dev_utility_test_example"
+
+[[repo]]
+url = "https://github.com/isyuz/movePlotFile"
+
+[[repo]]
+url = "https://github.com/OSI-Yazilim/chia-plotter-docker"
+
+[[repo]]
+url = "https://github.com/SimonKepp/chia-archiver"
+
+[[repo]]
+url = "https://github.com/VoidXH/ChiaPerformanceCheck"
+
+[[repo]]
+url = "https://github.com/flovearth/17_ChiaNetwork-"
+
+[[repo]]
+url = "https://github.com/tomand285/chiaMover"
+
+[[repo]]
+url = "https://github.com/deatheibon/cmk_chia"
+
+[[repo]]
+url = "https://github.com/isezen/chiax"
+
+[[repo]]
+url = "https://github.com/ychang-cn/ChiaPlotter"
+
+[[repo]]
+url = "https://github.com/ggwilly/ChiaScripts"
+
+[[repo]]
+url = "https://github.com/mitchweaver/chia"
+
+[[repo]]
+url = "https://github.com/romanlegeza/chia-hpool-checker"
+
+[[repo]]
+url = "https://github.com/Lyndeno/chia_scripts"
+
+[[repo]]
+url = "https://github.com/xiaoliwe/xchrobot"
+
+[[repo]]
+url = "https://github.com/loguntsov/echiapos"
+
+[[repo]]
+url = "https://github.com/dyluth/chia"
+
+[[repo]]
+url = "https://github.com/polarn/chia-hpool-docker"
+
+[[repo]]
+url = "https://github.com/danbembower/ChiaPlottingGroupStarter"
+
+[[repo]]
+url = "https://github.com/distoration/AutoDisker-0.1v-PYTHON"
+
+[[repo]]
+url = "https://github.com/Pow-Duck/Chia-FAQ"
+
+[[repo]]
+url = "https://github.com/Wujiao233/Scriptable-HPool-Chia-widget"
+
+[[repo]]
+url = "https://github.com/xelzin/ubuntu-vnc-desktop"
+
+[[repo]]
+url = "https://github.com/cracklingice/Plot-Copy-Multi"
+
+[[repo]]
+url = "https://github.com/dolguin-/chia-k8s"
+
+[[repo]]
+url = "https://github.com/ForestCrazy/chia-node-list-api"
+
+[[repo]]
+url = "https://github.com/markessien/meplotter"
+
+[[repo]]
+url = "https://github.com/somanysteves/power-chia"
+
+[[repo]]
+url = "https://github.com/red2-io/chia-docker-plottools"
+
+[[repo]]
+url = "https://github.com/jakalope/auto_plot"
+
+[[repo]]
+url = "https://github.com/jfikar/chia_scripts"
+
+[[repo]]
+url = "https://github.com/cgwyx/chia-docker-vnc-desktop-plotng"
+
+[[repo]]
+url = "https://github.com/cielu/chia-rpc-go"
+
+[[repo]]
+url = "https://github.com/Dennis1000/chia-blockchain-checkmk"
+
+[[repo]]
+url = "https://github.com/turekjiri/chia-plot-manager"
+
+[[repo]]
+url = "https://github.com/kikolouro/Chia-plotting"
+
+[[repo]]
+url = "https://github.com/amccarthy9904/chia_script"
+
+[[repo]]
+url = "https://github.com/MattN-HB/chiaexperiment"
+
+[[repo]]
+url = "https://github.com/navroudsari/chia_client"
+
+[[repo]]
+url = "https://github.com/bteehub/Chia"
+
+[[repo]]
+url = "https://github.com/19860207/Chia-blockchain-discord-supermine.io-pool"
+
+[[repo]]
+url = "https://github.com/Fmstrat/chia-docker"
+
+[[repo]]
+url = "https://github.com/skwakl/chia-plotman"
+
+[[repo]]
+url = "https://github.com/hhollenstain/linux_chia_swar"
+
+[[repo]]
+url = "https://github.com/johodh/chia-plot-utils"
+
+[[repo]]
+url = "https://github.com/amirhh00/chia-telegram-bot"
+
+[[repo]]
+url = "https://github.com/RalfEs73/create_chia_plots"
+
+[[repo]]
+url = "https://github.com/JoshuaBiLink/EasyPlotter"
+
+[[repo]]
+url = "https://github.com/martinj/chia-farm-monitor-pushover"
+
+[[repo]]
+url = "https://github.com/martinj/chia-farm-monitor"
+
+[[repo]]
+url = "https://github.com/IanVand/plotboy"
+
+[[repo]]
+url = "https://github.com/bretmlw/chiainfo.live"
+
+[[repo]]
+url = "https://github.com/martinj/chia-farm-summary"
+
+[[repo]]
+url = "https://github.com/whirly1227/ChiaFileMover"
+
+[[repo]]
+url = "https://github.com/ssysm/ChiaPlotStat"
+
+[[repo]]
+url = "https://github.com/martinj/chia-log-parser"
+
+[[repo]]
+url = "https://github.com/chia-toolkit/curl"
+
+[[repo]]
+url = "https://github.com/ff522/ChiaPlotHelper"
+
+[[repo]]
+url = "https://github.com/tyc4d/chia-version-update-notification"
+
+[[repo]]
+url = "https://github.com/Leticijak/CHIA"
+
+[[repo]]
+url = "https://github.com/c0decave/chia_network"
+
+[[repo]]
+url = "https://github.com/EntySquare/chiable"
+
+[[repo]]
+url = "https://github.com/hexwhyzet/chiaLogsParser"
+
+[[repo]]
+url = "https://github.com/Markhenn/chia_helper"
+
+[[repo]]
+url = "https://github.com/Lykos153/chia-docker"
+
+[[repo]]
+url = "https://github.com/ChiaMonster/awesome-chia"
+
+[[repo]]
+url = "https://github.com/cracklingice/Chia-Plot-Instance-Launcher"
+
+[[repo]]
+url = "https://github.com/mjsr/chia-architecture"
+
+[[repo]]
+url = "https://github.com/alexander-e-andrews/ChiaPlotManager"
+
+[[repo]]
+url = "https://github.com/lilei105/WinPlotter"
+
+[[repo]]
+url = "https://github.com/fcmfcm01/chia-cli"
+
+[[repo]]
+url = "https://github.com/gaplo917/simple-chia-plotting"
+
+[[repo]]
+url = "https://github.com/lunamcsv/chia-rest-api"
+
+[[repo]]
+url = "https://github.com/pieterhelsen/chia-pchecker"
+
+[[repo]]
+url = "https://github.com/robertmetcalf/chia-log"
+
+[[repo]]
+url = "https://github.com/mattsahr/chiasoup"
+
+[[repo]]
+url = "https://github.com/Umiiii/chia-plot-analyser"
+
+[[repo]]
+url = "https://github.com/mblackman/ChiaFarmManager"
+
+[[repo]]
+url = "https://github.com/cthiel42/chia-exporter"
+
+[[repo]]
+url = "https://github.com/mblackman/chia-farm-api"
+
+[[repo]]
+url = "https://github.com/petemcw/docker-chia-network"
+
+[[repo]]
+url = "https://github.com/yrjo/chia-container"
+
+[[repo]]
+url = "https://github.com/Quexington/tree-sitter-chialisp"
+
+[[repo]]
+url = "https://github.com/olafkotur/chia-rig-cluster"
+
+[[repo]]
+url = "https://github.com/Nam-K/Chia_Network.Tools"
+
+[[repo]]
+url = "https://github.com/nemothenoone/chia_network.nemo1369-vdf-track2"
+
+[[repo]]
+url = "https://github.com/ant013/crypto-bls-ios"
+
+[[repo]]
+url = "https://github.com/nmarley/js-bls-signatures-playground

--- a/data/ecosystems/c/chia.toml
+++ b/data/ecosystems/c/chia.toml
@@ -1242,7 +1242,8 @@ url = "https://github.com/farmerdiamonds/chia-walletbalance-nodejs"
 [[repo]]
 url = "https://github.com/bringyour/go-xch"
 
-https://github.com/FireAcademy/golden-gate"
+[[repo]]
+url = "https://github.com/FireAcademy/golden-gate"
 
 [[repo]]
 url = "https://github.com/MaximEdogawa/seedener"
@@ -2001,4 +2002,4 @@ url = "https://github.com/nemothenoone/chia_network.nemo1369-vdf-track2"
 url = "https://github.com/ant013/crypto-bls-ios"
 
 [[repo]]
-url = "https://github.com/nmarley/js-bls-signatures-playground
+url = "https://github.com/nmarley/js-bls-signatures-playground"


### PR DESCRIPTION
https://dev.chialinks.com tracks GitHub repos contributing to the Chia ecosystem. This PR adds an additional 254 repos not currently on the list.