### PR TITLE
remove non-bitcoin projects

### DIFF
--- a/data/ecosystems/b/bitcoin.toml
+++ b/data/ecosystems/b/bitcoin.toml
@@ -125,9 +125,6 @@ url = "https://github.com/bitaccess/aave-cash"
 url = "https://github.com/bitaccess/ba-sweep"
 
 [[repo]]
-url = "https://github.com/bitaccess/bcashjs-lib"
-
-[[repo]]
 url = "https://github.com/bitaccess/bcoin-access-api-docker"
 
 [[repo]]
@@ -147,9 +144,6 @@ url = "https://github.com/bitaccess/bitcoin-js-test"
 
 [[repo]]
 url = "https://github.com/bitaccess/bitcoin-wallet"
-
-[[repo]]
-url = "https://github.com/bitaccess/bitcoincashjs"
 
 [[repo]]
 url = "https://github.com/bitaccess/bitcoinjs-lib"
@@ -227,9 +221,6 @@ url = "https://github.com/bitaccess/node-cache-manager-ioredis"
 url = "https://github.com/bitaccess/nodecloud-scripts"
 
 [[repo]]
-url = "https://github.com/bitaccess/nodejs-getting-started"
-
-[[repo]]
 url = "https://github.com/bitaccess/parse-usdl"
 
 [[repo]]
@@ -242,15 +233,6 @@ url = "https://github.com/bitaccess/public_bucket"
 url = "https://github.com/bitaccess/python-shamir-mnemonic"
 
 [[repo]]
-url = "https://github.com/bitaccess/slate"
-
-[[repo]]
-url = "https://github.com/bitaccess/speedtest.net"
-
-[[repo]]
-url = "https://github.com/bitaccess/subdir-heroku-buildpack"
-
-[[repo]]
 url = "https://github.com/bitaccess/thunderhub"
 
 [[repo]]
@@ -261,9 +243,6 @@ url = "https://github.com/bitaccess/ts-config"
 
 [[repo]]
 url = "https://github.com/bitaccess/zbar"
-
-[[repo]]
-url = "https://github.com/Bitcoin-ABC/bitcoin-abc"
 
 [[repo]]
 url = "https://github.com/bitcoin-abe/bitcoin-abe"
@@ -646,16 +625,6 @@ url = "https://github.com/bitcoinops/taproot"
 
 [[repo]]
 url = "https://github.com/bitcoinops/taproot-workshop"
-
-[[repo]]
-url = "https://github.com/BitcoinUnlimited/BitcoinUnlimited"
-tags = ["Protocol"]
-
-[[repo]]
-url = "https://github.com/BitGo/eth-contracts"
-
-[[repo]]
-url = "https://github.com/BitGo/smart-contracts"
 
 [[repo]]
 url = "https://github.com/bithyve/hexa"
@@ -1198,15 +1167,6 @@ url = "https://github.com/EdgeApp/android-ndk-macos"
 url = "https://github.com/EdgeApp/asmcrypto.js"
 
 [[repo]]
-url = "https://github.com/EdgeApp/augur"
-
-[[repo]]
-url = "https://github.com/EdgeApp/augur-ui-react-components"
-
-[[repo]]
-url = "https://github.com/EdgeApp/augur.js"
-
-[[repo]]
 url = "https://github.com/EdgeApp/baselet"
 
 [[repo]]
@@ -1396,9 +1356,6 @@ url = "https://github.com/EdgeApp/edge-reports-server"
 url = "https://github.com/EdgeApp/edge-rest-wallet"
 
 [[repo]]
-url = "https://github.com/EdgeApp/edge-ripple-keypairs"
-
-[[repo]]
 url = "https://github.com/EdgeApp/edge-server-simplex"
 
 [[repo]]
@@ -1441,18 +1398,6 @@ url = "https://github.com/EdgeApp/eip-961-qr-generator"
 url = "https://github.com/EdgeApp/electrumX"
 
 [[repo]]
-url = "https://github.com/EdgeApp/eosjs-api"
-
-[[repo]]
-url = "https://github.com/EdgeApp/eosjs-node-cli"
-
-[[repo]]
-url = "https://github.com/EdgeApp/ethereumjs-wallet"
-
-[[repo]]
-url = "https://github.com/EdgeApp/ethrpc"
-
-[[repo]]
 url = "https://github.com/EdgeApp/eztz"
 
 [[repo]]
@@ -1460,9 +1405,6 @@ url = "https://github.com/EdgeApp/github-action-file-sync"
 
 [[repo]]
 url = "https://github.com/EdgeApp/indy"
-
-[[repo]]
-url = "https://github.com/EdgeApp/js-stellar-sdk"
 
 [[repo]]
 url = "https://github.com/EdgeApp/json-csv"
@@ -1487,12 +1429,6 @@ url = "https://github.com/EdgeApp/libwallet"
 
 [[repo]]
 url = "https://github.com/EdgeApp/memlet"
-
-[[repo]]
-url = "https://github.com/EdgeApp/mymonero-core-js"
-
-[[repo]]
-url = "https://github.com/EdgeApp/mymonero-utils"
 
 [[repo]]
 url = "https://github.com/EdgeApp/Proposed-Redux-State"
@@ -1622,9 +1558,6 @@ url = "https://github.com/EdgeApp/wuc-new"
 
 [[repo]]
 url = "https://github.com/EdgeApp/yaob"
-
-[[repo]]
-url = "https://github.com/EdgeApp/zcash-demo-app"
 
 [[repo]]
 url = "https://github.com/Ekliptor/WolfBot"
@@ -1764,9 +1697,6 @@ url = "https://github.com/kristapsk/bitcoin-scripts"
 url = "https://github.com/kristapsk/segvan"
 
 [[repo]]
-url = "https://github.com/kyuupichan/electrumx"
-
-[[repo]]
 url = "https://github.com/L2-Technology/sensei"
 
 [[repo]]
@@ -1855,9 +1785,6 @@ url = "https://github.com/MaibornWolff/bitcoin.me"
 
 [[repo]]
 url = "https://github.com/mcdee/blockparser"
-
-[[repo]]
-url = "https://github.com/mempool/.github"
 
 [[repo]]
 url = "https://github.com/mempool/asset_registry_db"
@@ -2534,9 +2461,6 @@ url = "https://github.com/rust-bitcoin/rust-secp256k1"
 
 [[repo]]
 url = "https://github.com/rust-bitcoin/rust-wallet"
-
-[[repo]]
-url = "https://github.com/ryanxcharles/yours-bitcoin"
 
 [[repo]]
 url = "https://github.com/Samourai-Wallet/addrindexrs"


### PR DESCRIPTION
The projects either no longer exist or are solely dedicated to an ecosystem other than BTC