### PR TITLE
Update Cardano.toml to include Aiken repository url

### DIFF
--- a/data/ecosystems/c/cardano.toml
+++ b/data/ecosystems/c/cardano.toml
@@ -73,6 +73,9 @@ url = "https://github.com/ADAPhilippines/ADAPH.TxSubmit"
 url = "https://github.com/aiken-lang/editor-integration-nvim"
 
 [[repo]]
+url = "https://github.com/aiken-lang/aiken"
+
+[[repo]]
 url = "https://github.com/Akagi201/learning-cardano"
 
 [[repo]]


### PR DESCRIPTION
Added missing Aiken repository URL in Cardano 