### PR TITLE
Adds "celo-examples" gh org holding tutorial repos

### DIFF
--- a/data/ecosystems/c/celo.toml
+++ b/data/ecosystems/c/celo.toml
@@ -79,6 +79,7 @@ github_organizations = [
   "https://github.com/celo-org",
   "https://github.com/celo-tools",
   "https://github.com/celo-tracker",
+  "https://github.com/celo-examples",
   "https://github.com/dapplooker",
   "https://github.com/helpicelo",
   "https://github.com/Pinnata",


### PR DESCRIPTION
This repo holds community contributed repos and examples. heads up @joenyzio @viral-sangani