### PR TITLE
Added the github repo of TITA

### DIFF
--- a/data/ecosystems/c/celo.toml
+++ b/data/ecosystems/c/celo.toml
@@ -6006,3 +6006,9 @@ url = "https://gitlab.com/pretoria-research-lab/celo-faucet-api"
 
 [[repo]]
 url = "https://github.com/Muhindo-Galien/Yob-Ticketing-dapp"
+
+[[repo]]
+url = "https://github.com/DevZibah/Tita"
+
+[[repo]]
+url = "https://github.com/DevZibah/Tita-smart-contract"


### PR DESCRIPTION
Team TITA emerged as one of the most notable projects in the just concluded Women Build Celo Hackathon. I added TITA's repo to the celo.toml file.