### PR TITLE
Adding Hypha DAO repos

### DIFF
--- a/data/ecosystems/e/eos.toml
+++ b/data/ecosystems/e/eos.toml
@@ -16,6 +16,7 @@ sub_ecosystems = [
   "Eva",
   "Everipedia",
   "FeeSimple",
+  "Hypha DAO",
   "Iryo Network",
   "MEET.ONE",
   "Scatter",
@@ -35,6 +36,7 @@ github_organizations = [
   "https://github.com/eosio-eps",
   "https://github.com/eosnewyork",
   "https://github.com/eosrio",
+  "https://github.com/hypha-dao",
 ]
 
 # Repositories
@@ -1598,3 +1600,38 @@ url = "https://github.com/youbaoio/eos3d-contract"
 
 [[repo]]
 url = "https://github.com/zachalam/namevault"
+
+[[repo]]
+url = "https://github.com/hypha-dao/dho-web-client"
+tags = ["Dapp"]
+
+[[repo]]
+url = "https://github.com/hypha-dao/hypha_wallet"
+tags = ["Wallet"]
+
+[[repo]]
+url = "https://github.com/hypha-dao/dao-contracts"
+
+[[repo]]
+url = "https://github.com/hypha-dao/document-graph"
+
+[[repo]]
+url = "https://github.com/hypha-dao/ual-hypha"
+
+[[repo]]
+url = "https://github.com/hypha-dao/hypha-document-cache-gql-go"
+
+[[repo]]
+url = "https://github.com/hypha-dao/hypha-smart-contracts"
+
+[[repo]]
+url = "https://github.com/hypha-dao/ppp-api"
+
+[[repo]]
+url = "https://github.com/hypha-dao/document-graph"
+
+[[repo]]
+url = "https://github.com/hypha-dao/kv-eosio-contracts"
+
+[[repo]]
+url = "https://github.com/hypha-dao/voice-token"

--- a/data/ecosystems/e/eos.toml
+++ b/data/ecosystems/e/eos.toml
@@ -16,7 +16,6 @@ sub_ecosystems = [
   "Eva",
   "Everipedia",
   "FeeSimple",
-  "Hypha DAO",
   "Iryo Network",
   "MEET.ONE",
   "Scatter",


### PR DESCRIPTION
# Hypha DAO

Hypha DAO is a project running on Telos and EOS Antelope chains. 

https://hypha.earth

Hypha has received a grant by the ENF to deploy our DAO product on EOS, we are currently working towards a beta launch. 

## What is in this PR

This PR contains all relevant, recent and public repositories for making Hypha DAO run, including

- The Hypha DAO Dapp
- Hypha Wallet (signing wallet)
- Various Hypha DAO smart contracts
- Utilities

Let me know if there are any questions, thank you!

I also see there's 2 more EOS ecosystem additions - I will be very happy to merge those changes into this PR in case there's conflicts. 

Thank you! 