### PR TITLE
Additions to Ava Labs

### DIFF
--- a/data/ecosystems/a/avalanche.toml
+++ b/data/ecosystems/a/avalanche.toml
@@ -548,6 +548,9 @@ url = "https://github.com/ava-labs/lotus-docs"
 url = "https://github.com/ava-labs/mastering-avalanche"
 
 [[repo]]
+url = "https://github.com/ava-labs/mnemonic-shamir-secret-sharing-cli"
+
+[[repo]]
 url = "https://github.com/ava-labs/multicall"
 
 [[repo]]


### PR DESCRIPTION
Add [mnemonic-shamir-secret-sharing-cli](https://github.com/ava-labs/mnemonic-shamir-secret-sharing-cli) repo for Ava Labs.