### PR TITLE
new Avalanche repos add

### DIFF
--- a/data/ecosystems/a/avalanche.toml
+++ b/data/ecosystems/a/avalanche.toml
@@ -2260,3 +2260,11 @@ url = "https://github.com/Ziden/CryptoCharacters"
 
 [[repo]]
 url = "https://github.com/ZILECAO/web3-studocu"
+
+[[repo]]
+url = "https://github.com/izzetemredemir/Avalanche-NFT-Aggregator"
+tags = [ "NFT","Aggregator"]
+
+[[repo]]
+url = "https://github.com/monopayments/mono-carbon"
+tags = [ "Refi","Carbon Marketplace", "Hackhaton"]

--- a/data/ecosystems/a/avalanche.toml
+++ b/data/ecosystems/a/avalanche.toml
@@ -2264,7 +2264,3 @@ url = "https://github.com/ZILECAO/web3-studocu"
 [[repo]]
 url = "https://github.com/izzetemredemir/Avalanche-NFT-Aggregator"
 tags = [ "NFT","Aggregator"]
-
-[[repo]]
-url = "https://github.com/monopayments/mono-carbon"
-tags = [ "Refi","Carbon Marketplace", "Hackhaton"]


### PR DESCRIPTION
I've added links to the Avalanche NFT aggregator and the second-place Avalanche Akbank Refi hackathon project, Mono Carbon, to our repository for easy access and reference.