### PR TITLE
Additions to Ava Labs

### DIFF
--- a/data/ecosystems/a/avalanche.toml
+++ b/data/ecosystems/a/avalanche.toml
@@ -818,6 +818,9 @@ url = "https://github.com/Cestafinance/cesta-app"
 url = "https://github.com/ceyonur/electanon"
 
 [[repo]]
+url = "https://github.com/cgcardona/avalanche-oh-my-zsh-plugin"
+
+[[repo]]
 url = "https://github.com/cgcardona/AVAX-hd-address-generator"
 
 [[repo]]


### PR DESCRIPTION
- Add [avalanche-oh-my-zsh-plugin ](https://github.com/cgcardona/avalanche-oh-my-zsh-plugin) repo for Ava Labs.