### PR TITLE
Adding EOS organizations and repositories

### DIFF
--- a/data/ecosystems/e/eos.toml
+++ b/data/ecosystems/e/eos.toml
@@ -38,6 +38,8 @@ github_organizations = [
   "https://github.com/hypha-dao",
   "https://github.com/greymass",
   "https://github.com/wharfkit",
+  "https://github.com/eosnetworkfoundation",
+  "https://github.com/AntelopeIO",
 ]
 
 # Repositories
@@ -1807,3 +1809,51 @@ url = "https://github.com/wharfkit/wallet-plugin-scatter"
 
 [[repo]]
 url = "https://github.com/wharfkit/account"
+
+[[repo]]
+url = "https://github.com/eosnetworkfoundation/eos-evm"
+
+[[repo]]
+url = "https://github.com/eosnetworkfoundation/evm-bridge-frontend"
+
+[[repo]]
+url = "https://github.com/eosnetworkfoundation/eos-evm-node"
+
+[[repo]]
+url = "https://github.com/eosnetworkfoundation/evm-bridge-contracts"
+
+[[repo]]
+url = "https://github.com/eosnetworkfoundation/eos-evm-miner"
+
+[[repo]]
+url = "https://github.com/eosnetworkfoundation/web-ide-ui"
+
+[[repo]]
+url = "https://github.com/eosnetworkfoundation/web-ide-api"
+
+[[repo]]
+url = "https://github.com/eosnetworkfoundation/docs"
+
+[[repo]]
+url = "https://github.com/eosnetworkfoundation/docs-ui"
+
+[[repo]]
+url = "https://github.com/eosnetworkfoundation/devhub"
+
+[[repo]]
+url = "https://github.com/AntelopeIO/leap"
+
+[[repo]]
+url = "https://github.com/AntelopeIO/cdt"
+
+[[repo]]
+url = "https://github.com/AntelopeIO/eos-vm"
+
+[[repo]]
+url = "https://github.com/AntelopeIO/chainbase"
+
+[[repo]]
+url = "https://github.com/AntelopeIO/appbase"
+
+[[repo]]
+url = "https://github.com/AntelopeIO/DUNES"


### PR DESCRIPTION
Hello!

I'd like to add some more recent data to the EOS ecosystem please. 

There are two primary orgs that are missing:
- [EOS Network Foundation](https://github.com/orgs/eosnetworkfoundation/) - EOS-specific code and EOS EVM
- [AntelopeIO](https://github.com/AntelopeIO) - The Antelope protocol (the successor to EOSIO, and the tech that the foundation develops to power EOS)

I've also added the most important repositories from both of them as well. 
