### PR TITLE
proj: add hedera-dev org + repos to the hedera config

### DIFF
--- a/data/ecosystems/h/hedera.toml
+++ b/data/ecosystems/h/hedera.toml
@@ -22,6 +22,7 @@ sub_ecosystems = [
 
 github_organizations = [
   "https://github.com/hashgraph",
+  "https://github.com/hedera-dev",
   "https://github.com/Hashpack",
   "https://github.com/linkd-network",
 ]
@@ -1299,6 +1300,54 @@ url = "https://github.com/HbarSuite/open-dapp"
 
 [[repo]]
 url = "https://github.com/hdn-labs/hdn-contracts"
+
+[[repo]]
+url = "https://github.com/hedera-dev/hedera-code-snippets"
+
+[[repo]]
+url = "https://github.com/hedera-dev/hedera-example-metamask-inventory-getter-setter"
+
+[[repo]]
+url = "https://github.com/hedera-dev/hedera-smart-contracts-workshop"
+
+[[repo]]
+url = "https://github.com/hedera-dev/voting-contract-workshop"
+
+[[repo]]
+url = "https://github.com/hedera-dev/hedera-smart-contract-testing-with-foundry-JS"
+
+[[repo]]
+url = "https://github.com/hedera-dev/hedera-smart-contract-testing-with-foundry"
+
+[[repo]]
+url = "https://github.com/hedera-dev/js-testing"
+
+[[repo]]
+url = "https://github.com/hedera-dev/cra-hedera-dapp-template-js"
+
+[[repo]]
+url = "https://github.com/hedera-dev/multi-wallet-hedera-transfer-dapp"
+
+[[repo]]
+url = "https://github.com/hedera-dev/multi-wallet-hedera-transfer-dapp-js"
+
+[[repo]]
+url = "https://github.com/hedera-dev/cra-hedera-dapp-template"
+
+[[repo]]
+url = "https://github.com/hedera-dev/hedera-example-metamask-token-associator"
+
+[[repo]]
+url = "https://github.com/hedera-dev/hedera-create-account-and-token-helper"
+
+[[repo]]
+url = "https://github.com/hedera-dev/hedera-example-metamask-counter-dapp"
+
+[[repo]]
+url = "https://github.com/hedera-dev/java-coin-workshop"
+
+[[repo]]
+url = "https://github.com/hedera-dev/hedera-dapp-days"
 
 [[repo]]
 url = "https://github.com/Hedera-examples/SmartContractService"


### PR DESCRIPTION
## What

- add `https://github.com/hedera-dev` to `github_organizations` in `data/ecosystems/h/hedera.toml`
- also add its repos under `[[repo]]` sections

## Why

- The `hedera-dev` github org contains many demo repos, code snippets, and templates used by developers building on Hedera