### PR TITLE
Add InterPlanetary Consensus

### DIFF
--- a/data/ecosystems/f/filecoin.toml
+++ b/data/ecosystems/f/filecoin.toml
@@ -8,7 +8,7 @@ sub_ecosystems = [
   "InterPlanetary Consensus",  
   "NFT Storage",
   "Slate Engineering Services",
-  "Web3 Storage"
+  "Web3 Storage",
 ]
 
 github_organizations = ["https://github.com/filecoin-project", "https://github.com/filecoin-shipyard"]

--- a/data/ecosystems/f/filecoin.toml
+++ b/data/ecosystems/f/filecoin.toml
@@ -11,7 +11,7 @@ sub_ecosystems = [
   "InterPlanetary Consensus"
 ]
 
-github_organizations = ["https://github.com/filecoin-project", "https://github.com/filecoin-shipyard","https://github.com/consensus-shipyard/"]
+github_organizations = ["https://github.com/filecoin-project", "https://github.com/filecoin-shipyard", "https://github.com/consensus-shipyard/"]
 
 # Repositories
 [[repo]]

--- a/data/ecosystems/f/filecoin.toml
+++ b/data/ecosystems/f/filecoin.toml
@@ -8,9 +8,10 @@ sub_ecosystems = [
   "NFT Storage",
   "Slate Engineering Services",
   "Web3 Storage",
+  "InterPlanetary Consensus"
 ]
 
-github_organizations = ["https://github.com/filecoin-project", "https://github.com/filecoin-shipyard"]
+github_organizations = ["https://github.com/filecoin-project", "https://github.com/filecoin-shipyard","https://github.com/consensus-shipyard/"]
 
 # Repositories
 [[repo]]
@@ -71,7 +72,31 @@ url = "https://github.com/collective-dao/collectif-fevm-frontend-template"
 url = "https://github.com/collective-dao/liquid-staking"
 
 [[repo]]
+url = "https://github.com/consensus-shipyard/calibration"
+
+[[repo]]
+url = "https://github.com/consensus-shipyard/consensuslab"
+
+[[repo]]
+url = "https://github.com/consensus-shipyard/docs"
+
+[[repo]]
+url = "https://github.com/consensus-shipyard/fendermint"
+
+[[repo]]
+url = "https://github.com/consensus-shipyard/ipc"
+
+[[repo]]
+url = "https://github.com/consensus-shipyard/ipc-actors"
+
+[[repo]]
+url = "https://github.com/consensus-shipyard/ipc-ipld-resolver"
+
+[[repo]]
 url = "https://github.com/consensus-shipyard/ipc-solidity-actors"
+
+[[repo]]
+url = "https://github.com/consensus-shipyard/ipc-trampoline"
 
 [[repo]]
 url = "https://github.com/consensus-shipyard/lotus"
@@ -237,6 +262,9 @@ url = "https://github.com/filecoin-project/ent"
 
 [[repo]]
 url = "https://github.com/filecoin-project/eudico"
+
+[[repo]]
+url = "https://github.com/filecoin-project/f3"
 
 [[repo]]
 url = "https://github.com/filecoin-project/fevm-contract-tests"

--- a/data/ecosystems/f/filecoin.toml
+++ b/data/ecosystems/f/filecoin.toml
@@ -5,13 +5,13 @@ sub_ecosystems = [
   "Application Research Group",
   "Collectif DAO",
   "Glif",
+  "InterPlanetary Consensus",  
   "NFT Storage",
   "Slate Engineering Services",
-  "Web3 Storage",
-  "InterPlanetary Consensus"
+  "Web3 Storage"
 ]
 
-github_organizations = ["https://github.com/filecoin-project", "https://github.com/filecoin-shipyard", "https://github.com/consensus-shipyard/"]
+github_organizations = ["https://github.com/filecoin-project", "https://github.com/filecoin-shipyard"]
 
 # Repositories
 [[repo]]
@@ -70,39 +70,6 @@ url = "https://github.com/collective-dao/collectif-fevm-frontend-template"
 
 [[repo]]
 url = "https://github.com/collective-dao/liquid-staking"
-
-[[repo]]
-url = "https://github.com/consensus-shipyard/calibration"
-
-[[repo]]
-url = "https://github.com/consensus-shipyard/consensuslab"
-
-[[repo]]
-url = "https://github.com/consensus-shipyard/docs"
-
-[[repo]]
-url = "https://github.com/consensus-shipyard/fendermint"
-
-[[repo]]
-url = "https://github.com/consensus-shipyard/ipc"
-
-[[repo]]
-url = "https://github.com/consensus-shipyard/ipc-actors"
-
-[[repo]]
-url = "https://github.com/consensus-shipyard/ipc-ipld-resolver"
-
-[[repo]]
-url = "https://github.com/consensus-shipyard/ipc-solidity-actors"
-
-[[repo]]
-url = "https://github.com/consensus-shipyard/ipc-trampoline"
-
-[[repo]]
-url = "https://github.com/consensus-shipyard/lotus"
-
-[[repo]]
-url = "https://github.com/consensus-shipyard/spacenet"
 
 [[repo]]
 url = "https://github.com/ConsenSys/fc-latency-map"
@@ -259,9 +226,6 @@ url = "https://github.com/filecoin-project/ec-gpu"
 
 [[repo]]
 url = "https://github.com/filecoin-project/ent"
-
-[[repo]]
-url = "https://github.com/filecoin-project/eudico"
 
 [[repo]]
 url = "https://github.com/filecoin-project/f3"
@@ -644,9 +608,6 @@ url = "https://github.com/filecoin-project/merkletree"
 
 [[repo]]
 url = "https://github.com/filecoin-project/meta-aggregator-frontend"
-
-[[repo]]
-url = "https://github.com/filecoin-project/mir"
 
 [[repo]]
 url = "https://github.com/filecoin-project/motion"

--- a/data/ecosystems/i/interplanetary-consensus.toml
+++ b/data/ecosystems/i/interplanetary-consensus.toml
@@ -37,6 +37,9 @@ url = "https://github.com/consensus-shipyard/ipc-trampoline"
 url = "https://github.com/consensus-shipyard/lotus"
 
 [[repo]]
+url = "https://github.com/consensus-shipyard/spacenet"
+
+[[repo]]
 url = "https://github.com/filecoin-project/eudico"
 
 [[repo]]

--- a/data/ecosystems/i/interplanetary-consensus.toml
+++ b/data/ecosystems/i/interplanetary-consensus.toml
@@ -1,0 +1,43 @@
+# Ecosystem Level Information
+title = "InterPlanetary Consensus"
+
+sub_ecosystems = []
+
+github_organizations = ["https://github.com/consensus-shipyard"]
+
+# Repositories
+[[repo]]
+url = "https://github.com/consensus-shipyard/calibration"
+
+[[repo]]
+url = "https://github.com/consensus-shipyard/consensuslab"
+
+[[repo]]
+url = "https://github.com/consensus-shipyard/docs"
+
+[[repo]]
+url = "https://github.com/consensus-shipyard/fendermint"
+
+[[repo]]
+url = "https://github.com/consensus-shipyard/ipc"
+
+[[repo]]
+url = "https://github.com/consensus-shipyard/ipc-actors"
+
+[[repo]]
+url = "https://github.com/consensus-shipyard/ipc-ipld-resolver"
+
+[[repo]]
+url = "https://github.com/consensus-shipyard/ipc-solidity-actors"
+
+[[repo]]
+url = "https://github.com/consensus-shipyard/ipc-trampoline"
+
+[[repo]]
+url = "https://github.com/consensus-shipyard/lotus"
+
+[[repo]]
+url = "https://github.com/filecoin-project/eudico"
+
+[[repo]]
+url = "https://github.com/filecoin-project/mir"


### PR DESCRIPTION
Adds a number of missing repos, mainly related to Filecoin's [InterPlanetary Consensus](https://filecoin.io/blog/posts/achieving-breakthrough-scalability-with-interplanetary-consensus-ipc/).

It's not entirely clear whether it makes sense to duplicate repos in the parent and sub ecosystems, but that seems to be the case already for other entries.