### PR TITLE
Fix outdated DipDup links

### DIFF
--- a/data/ecosystems/d/dipdup.toml
+++ b/data/ecosystems/d/dipdup.toml
@@ -3,7 +3,7 @@ title = "DipDup"
 
 sub_ecosystems = []
 
-github_organizations = ["https://github.com/dipdup-net"]
+github_organizations = ["https://github.com/dipdup-io"]
 
 # Repositories
 [[repo]]
@@ -61,22 +61,19 @@ url = "https://github.com/dipdup-io/tezos-domains"
 url = "https://github.com/dipdup-io/workerpool"
 
 [[repo]]
-url = "https://github.com/dipdup-net/aiosignalrcore"
+url = "https://github.com/dipdup-io/aiosignalrcore"
 
 [[repo]]
-url = "https://github.com/dipdup-net/hicdex"
+url = "https://github.com/dipdup-io/hicdex"
 
 [[repo]]
-url = "https://github.com/dipdup-net/openapi-typescript-codegen"
+url = "https://github.com/dipdup-io/openapi-typescript-codegen"
 
 [[repo]]
-url = "https://github.com/dipdup-net/reorg-tracker"
+url = "https://github.com/dipdup-io/reorg-tracker"
 
 [[repo]]
-url = "https://github.com/dipdup-net/tezos-profiles"
+url = "https://github.com/dipdup-io/tzprofiles"
 
 [[repo]]
-url = "https://github.com/dipdup-net/tzprofiles"
-
-[[repo]]
-url = "https://github.com/dipdup-net/wiki.tezos.com"
+url = "https://github.com/dipdup-io/wiki.tezos.com"


### PR DESCRIPTION
We have renamed GitHub organization to match dipdup.io domain some time ago. Other links in `dipdup.toml` and `baking-bad.toml` may be outdated too. Are they verified/refreshed on schedule somewhere?