### PR TITLE
Add developer tooling repo for celo

### DIFF
--- a/data/ecosystems/c/celo.toml
+++ b/data/ecosystems/c/celo.toml
@@ -2426,9 +2426,6 @@ url = "https://github.com/celo-org/celo-token-list"
 url = "https://github.com/celo-org/celo-validator-signer-app"
 
 [[repo]]
-url = "https://github.com/celo-org/celocli"
-
-[[repo]]
 url = "https://github.com/celo-org/celostats-frontend"
 
 [[repo]]
@@ -2475,6 +2472,9 @@ url = "https://github.com/celo-org/dev-cli"
 
 [[repo]]
 url = "https://github.com/celo-org/DevRel"
+
+[[repo]]
+url = "https://github.com/celo-org/developer-tooling"
 
 [[repo]]
 url = "https://github.com/celo-org/docs"


### PR DESCRIPTION
add developer-tooling repo which contains packages split out from the core repo

remove celocli repo (not used)