### PR TITLE
Add L2 Iterative as an open-source organization

### DIFF
--- a/data/ecosystems/l/l2iterative.toml
+++ b/data/ecosystems/l/l2iterative.toml
@@ -1,0 +1,3 @@
+title = "L2 Iterative"
+
+github_organizations = ["https://github.com/l2iterative"]


### PR DESCRIPTION
L2 Iterative is a venture capital, but we have been hoping to become Paradigm or Geometry, in that we want to do more open-source work.

We already have released a few Rust-based crypto development tools for RISC Zero, specifically in the following two repos.
https://github.com/l2iterative/gdb0
https://github.com/l2iterative/profiler0

And we have been doing research related to verifying FHE in RISC Zero.
https://github.com/l2iterative/vfhe0

However, it is probably not the best idea to put this under RISC Zero's ecosystem. In the coming year, we plan to do the same for our other portfolio companies, including for Polyhedra, EigenLayer, Babylon, Elusiv. Therefore, we feel that it is a good idea to list as a separate organization, and we should be contributing a lot of new crypto-related code. 