### PR TITLE
Update hedera.toml

### DIFF
--- a/data/ecosystems/h/hedera.toml
+++ b/data/ecosystems/h/hedera.toml
@@ -28,6 +28,7 @@ github_organizations = [
   "https://github.com/hedera-dev",
   "https://github.com/Hashpack",
   "https://github.com/linkd-network",
+  "https://github.com/renderhive-project",
   "https://github.com/stader-labs"
 ]
 
@@ -2300,6 +2301,12 @@ url = "https://github.com/rayoz12/hadera-cert"
 
 [[repo]]
 url = "https://github.com/Rejolut/hedera-ios-sdk"
+
+[[repo]]
+url = "https://github.com/renderhive-project/renderhive-service-app"
+
+[[repo]]
+url = "https://github.com/renderhive-project/renderhive-smart-contracts"
 
 [[repo]]
 url = "https://github.com/renix-codex/hedera-connect"


### PR DESCRIPTION
Adding the open-source project "Renderhive" – The first web3-based crowdrendering platform for Blender.