### PR TITLE
Add the-creators-galaxy org and repos to hedera conifg.

### DIFF
--- a/data/ecosystems/h/hedera.toml
+++ b/data/ecosystems/h/hedera.toml
@@ -18,7 +18,6 @@ sub_ecosystems = [
   "Mintmaster Labs",
   "PieFi Platform",
   "SaucerSwap Labs",
-  "The Creators Galaxy",
   "Tuum Tech",
   "Trust Enterprises",
   "TxMQ, Inc",

--- a/data/ecosystems/h/hedera.toml
+++ b/data/ecosystems/h/hedera.toml
@@ -18,7 +18,7 @@ sub_ecosystems = [
   "Mintmaster Labs",
   "PieFi Platform",
   "SaucerSwap Labs",
-  "The Creator's Galaxy",
+  "The Creators Galaxy",
   "Tuum Tech",
   "Trust Enterprises",
   "TxMQ, Inc",

--- a/data/ecosystems/h/hedera.toml
+++ b/data/ecosystems/h/hedera.toml
@@ -18,6 +18,7 @@ sub_ecosystems = [
   "Mintmaster Labs",
   "PieFi Platform",
   "SaucerSwap Labs",
+  "The Creator's Galaxy",
   "Tuum Tech",
   "Trust Enterprises",
   "TxMQ, Inc",
@@ -28,7 +29,8 @@ github_organizations = [
   "https://github.com/hedera-dev",
   "https://github.com/Hashpack",
   "https://github.com/linkd-network",
-  "https://github.com/stader-labs"
+  "https://github.com/stader-labs",
+  "https://github.com/the-creators-galaxy"
 ]
 
 # Repositories
@@ -2696,6 +2698,30 @@ url = "https://github.com/teritaris/hedera"
 
 [[repo]]
 url = "https://github.com/thatwist/hedera-course-demo"
+
+[[repo]]
+url = "https://github.com/the-creators-galaxy/hashpool"
+
+[[repo]]
+url = "https://github.com/the-creators-galaxy/hashpool-explorer"
+
+[[repo]]
+url = "https://github.com/the-creators-galaxy/hcs-governance"
+
+[[repo]]
+url = "https://github.com/the-creators-galaxy/hedera-test-scenario-creator"
+
+[[repo]]
+url = "https://github.com/the-creators-galaxy/hts-balance-api"
+
+[[repo]]
+url = "https://github.com/the-creators-galaxy/hts-circulating-supply-api"
+
+[[repo]]
+url = "https://github.com/the-creators-galaxy/hts-distribution-tool"
+
+[[repo]]
+url = "https://github.com/the-creators-galaxy/key-rotation-website"
 
 [[repo]]
 url = "https://github.com/The-Hashgraph-Association/tha-hedera-course"


### PR DESCRIPTION
# What

* add https://github.com/the-creators-galaxy to github_organizations in data/ecosystems/h/hedera.toml
* also add its repos under [[repo]] sections

# Why

* The [the-creators-galaxy](https://github.com/the-creators-galaxy) github org contains open source projects used by creatives, builders and developers building on Hedera