### PR TITLE
Add Helius GitHub Repos

### DIFF
--- a/data/ecosystems/s/solana.toml
+++ b/data/ecosystems/s/solana.toml
@@ -49887,6 +49887,33 @@ url = "https://github.com/helius-labs/royalties-example"
 url = "https://github.com/helius-labs/the-kitchen"
 
 [[repo]]
+url = "https://github.com/helius-labs/xray"
+
+[[repo]]
+url = "https://github.com/helius-labs/digital-asset-rpc-infrastructure"
+
+[[repo]]
+url = "https://github.com/helius-labs/helius-sdk"
+
+[[repo]]
+url = "https://github.com/helius-labs/helius-rpc-proxy"
+
+[[repo]]
+url = "https://github.com/helius-labs/pyre"
+
+[[repo]]
+url = "https://github.com/helius-labs/test-drive"
+
+[[repo]]
+url = "https://github.com/helius-labs/compression-examples"
+
+[[repo]]
+url = "https://github.com/helius-labs/yellowstone-grpc"
+
+[[repo]]
+url = "https://github.com/helius-labs/lite-rpc"
+
+[[repo]]
 url = "https://github.com/Helix51/Solana-3rd-Module-Project"
 
 [[repo]]


### PR DESCRIPTION
This PR aims to add all Helius-related GitHub repositories to `solana.toml`