### PR TITLE
chore: add squads v4 repo to Solana

### DIFF
--- a/data/ecosystems/s/solana.toml
+++ b/data/ecosystems/s/solana.toml
@@ -88903,6 +88903,9 @@ url = "https://github.com/Squads-Protocol/sqds"
 url = "https://github.com/Squads-Protocol/squads-mpl"
 
 [[repo]]
+url = "https://github.com/Squads-Protocol/v4"
+
+[[repo]]
 url = "https://github.com/SquareandCompass/anchor"
 
 [[repo]]


### PR DESCRIPTION
Adds the Squads-V4 protocol repo to `solana.toml`