### PR TITLE
Remove duplicate Stockpile repos

### DIFF
--- a/data/ecosystems/s/solana.toml
+++ b/data/ecosystems/s/solana.toml
@@ -90051,18 +90051,6 @@ url = "https://github.com/StockpileLabs/stockpile_sdk"
 url = "https://github.com/StockpileLabs/stockpile_sdk_example"
 
 [[repo]]
-url = "https://github.com/StockpileProtocol/open-grants-poc"
-
-[[repo]]
-url = "https://github.com/StockpileProtocol/stockpile"
-
-[[repo]]
-url = "https://github.com/StockpileProtocol/stockpile-v2"
-
-[[repo]]
-url = "https://github.com/StockpileProtocol/stockpile_react_sdk"
-
-[[repo]]
 url = "https://github.com/stocktiger/mmb"
 
 [[repo]]


### PR DESCRIPTION
We changed our GitHub org username from "StockpileProtocol" to "StockpileLabs", which created duplicates of the same repos in the list