### PR TITLE
fix: remove wrong repositories

### DIFF
--- a/data/ecosystems/i/interest-protocol.toml
+++ b/data/ecosystems/i/interest-protocol.toml
@@ -7,12 +7,6 @@ github_organizations = ["https://github.com/interest-protocol"]
 
 # Repositories
 [[repo]]
-url = "https://gfx.cafe/ip/app.git"
-
-[[repo]]
-url = "https://gfx.cafe/ip/contracts"
-
-[[repo]]
 url = "https://github.com/interest-protocol/amm"
 missing = true
 


### PR DESCRIPTION
We had wrong repositories listed under our organization.