### PR TITLE
Added Horseriders to huff.toml

### DIFF
--- a/data/ecosystems/h/huff.toml
+++ b/data/ecosystems/h/huff.toml
@@ -13,6 +13,9 @@ url = "https://github.com/0xcefa1090d/ape-huff"
 url = "https://github.com/0xsomnus/curta-archive"
 
 [[repo]]
+url = "https://github.com/BlocSoc-iitr/HorseRiders"
+
+[[repo]]
 url = "https://github.com/devtooligan/awesome-huff"
 
 [[repo]]


### PR DESCRIPTION
Added our open source project [Horseriders](https://github.com/BlocSoc-iitr/HorseRiders) to huff.toml

Horseriders is a complex math and Fast Fourier Transform Library for Huff and EVM Assembly