### PR TITLE
Add ABCDE Labs as an open-source Org

### DIFF
--- a/data/ecosystems/a/abcdelabs.toml
+++ b/data/ecosystems/a/abcdelabs.toml
@@ -1,0 +1,16 @@
+# Ecosystem Level Information
+title = "ABCDE Labs"
+
+sub_ecosystems = []
+
+github_organizations = ["https://github.com/ABCDELabs"]
+
+# Repositories
+[[repo]]
+url = "https://github.com/ABCDELabs/Understanding-Ethereum-Go-version"
+
+[[repo]]
+url = "https://github.com/ABCDELabs/parallel-go-ethereum"
+
+[[repo]]
+url = "https://github.com/ABCDELabs/Crypto4AI"


### PR DESCRIPTION
ABCDE Labs is an open source organization backed by ABCDE, focusing on Crypto Infra, ZK, Crypto AI and more. The code analysis manuals we have written have now gained over 400 Stars and have helped a number of developers in the community to be familiarized with the ethereum execution layer codebase.

https://github.com/ABCDELabs/Understanding-Ethereum-Go-version

We are also working on some cutting-edge PoCs, such as paralleli EVM, Native AI inference on Blockchain, etc.

https://github.com/ABCDELabs/parallel-go-ethereum