### PR TITLE
fix ideal labs repo url

### DIFF
--- a/data/ecosystems/p/polkadot-network.toml
+++ b/data/ecosystems/p/polkadot-network.toml
@@ -9285,11 +9285,7 @@ url = "https://github.com/Iceymann18777/extension"
 url = "https://github.com/idavollnetwork/idavoll"
 
 [[repo]]
-url = "https://github.com/ideal-lab5/cryptex-node"
-missing = true
-
-[[repo]]
-url = "https://github.com/ideal-lab5/iris"
+url = "https://github.com/ideal-lab5/etf"
 
 [[repo]]
 url = "https://github.com/idexio/DefiLlama-Adapters"

--- a/data/ecosystems/p/polkadot-network.toml
+++ b/data/ecosystems/p/polkadot-network.toml
@@ -9288,6 +9288,13 @@ url = "https://github.com/idavollnetwork/idavoll"
 url = "https://github.com/ideal-lab5/etf"
 
 [[repo]]
+url = "https://github.com/ideal-lab5/cryptex-node"
+missing = true
+
+[[repo]]
+url = "https://github.com/ideal-lab5/iris"
+
+[[repo]]
 url = "https://github.com/idexio/DefiLlama-Adapters"
 
 [[repo]]


### PR DESCRIPTION
The existing repo url does not exist. This PR adds the correct repo link.