### PR TITLE
add solcial to solana

### DIFF
--- a/data/ecosystems/s/solana.toml
+++ b/data/ecosystems/s/solana.toml
@@ -329,6 +329,7 @@ github_organizations = [
   "https://github.com/SerumTaxTime",
   "https://github.com/solana-developers",
   "https://github.com/solana-labs",
+  "https://github.com/solcial",
   "https://github.com/sollpay",
   "https://github.com/soluna-protocol",
   "https://github.com/Synthetify",


### PR DESCRIPTION
Solcial is a permissionless social network, that lets you invest in people.