### PR TITLE
add new DaVinciGraphNFTLocker repo

### DIFF
--- a/data/ecosystems/h/hedera.toml
+++ b/data/ecosystems/h/hedera.toml
@@ -981,6 +981,9 @@ url = "https://github.com/daviddprtma/Learning-Blockchain-Hedera-Fundamentals"
 url = "https://github.com/DaVinciGraph/davinci-pic"
 
 [[repo]]
+url = "https://github.com/DaVinciGraph/DaVinciGraphNFTLocker"
+
+[[repo]]
 url = "https://github.com/DaVinciGraph/DaVinciGraphBlackHole"
 
 [[repo]]


### PR DESCRIPTION
DaVinciGraphNFTLocker is the new Service of DaVinciGraph for locking NFTs on the Hedera ecosystem.