### PR TITLE
Add dojo engine

### DIFF
--- a/data/ecosystems/d/dojo-engine.toml
+++ b/data/ecosystems/d/dojo-engine.toml
@@ -97,7 +97,3 @@ url = "https://github.com/CollinViz/dojo-rollyouown-godot"
 [[repo]]
 
 url = "https://github.com/justinwangx/dojo-slot-machine"
-
-[[repo]]
-
-url = "

--- a/data/ecosystems/d/dojo-engine.toml
+++ b/data/ecosystems/d/dojo-engine.toml
@@ -3,7 +3,7 @@ title = "dojo-engine"
 
 sub_ecosystems = []
 
-github_organizations = ["https://github.com/dojo-engine/"]
+github_organizations = ["https://github.com/dojoengine/"]
 
 # Repositories
 [[repo]]
@@ -16,22 +16,25 @@ url = "https://github.com/BibliothecaDAO/loot-survivor"
 url = "https://github.com/BibliothecaDAO/eternum"
 
 [[repo]]
-url = "https://github.com/briqNFT"
+url = "https://github.com/briqNFT/briq-protocol"
 
 [[repo]]
-url = "https://github.com/influenceth"
-
-[[repo]]
-url = "https://github.com/pixelaw/"
+url = "https://github.com/pixelaw/core"
 
 [[repo]]
 url = "https://github.com/fundaomental/underdark"
 
 [[repo]]
-url = "https://github.com/z-korp"
+url = "https://github.com/z-korp/zconqueror-contracts"
 
 [[repo]]
-url = "https://github.com/starklandxyz"
+url = "https://github.com/z-korp/zknight-contracts"
+
+[[repo]]
+url = "https://github.com/z-korp/zdefender-contracts"
+
+[[repo]]
+url = "https://github.com/Starklandxyz/contract"
 
 [[repo]]
 url = "https://github.com/dojoengine/stark-lander"
@@ -43,10 +46,10 @@ url = "https://github.com/cartridge-gg/drive-ai"
 url = "https://github.com/keep-starknet-strange/tsubasa"
 
 [[repo]]
-url = "https://github.com/ArcaneAssemblers"
+url = "https://github.com/ArcaneAssemblers/spellcrafter"
 
 [[repo]]
-url = "https://github.com/0xDislands"
+url = "https://github.com/0xDislands/RPS_Dislands"
 
 [[repo]]
 url = "https://github.com/StarkExplore/Explore/"
@@ -55,45 +58,34 @@ url = "https://github.com/StarkExplore/Explore/"
 url = "https://github.com/DeograciousAggrey/crimedetective"
 
 [[repo]]
-
 url = "https://github.com/shramee/dojo-shooter"
 
 [[repo]]
-
 url = "https://github.com/codekaya/Pragma-Hackathon-DOJO-ARENA"
 
 [[repo]]
-
 url = "https://github.com/FrostStarBook/CoinBubble-PragmaCairoHackathon/"
 
 [[repo]]
-
 url = "https://github.com/rkdud007/chess-dojo"
 
 [[repo]]
-
 url = "https://github.com/thiscaspar/dojo-rps"
 
 [[repo]]
-
 url = "https://github.com/cartridge-gg/beer-baron"
 
 [[repo]]
-
-url = "https://github.com/maxgiraldo/0xfaeda.git"
-
-[[repo]]
-
-url = "https://github.com/Starknopoly"
+url = "https://github.com/maxgiraldo/0xfaeda"
 
 [[repo]]
+url = "https://github.com/Starknopoly/contracts"
 
+[[repo]]
 url = "https://github.com/dpinones/wordle-dojo"
 
 [[repo]]
-
 url = "https://github.com/CollinViz/dojo-rollyouown-godot"
 
 [[repo]]
-
 url = "https://github.com/justinwangx/dojo-slot-machine"

--- a/data/ecosystems/d/dojo-engine.toml
+++ b/data/ecosystems/d/dojo-engine.toml
@@ -47,3 +47,57 @@ url = "https://github.com/ArcaneAssemblers"
 
 [[repo]]
 url = "https://github.com/0xDislands"
+
+[[repo]]
+url = "https://github.com/StarkExplore/Explore/"
+
+[[repo]]
+url = "https://github.com/DeograciousAggrey/crimedetective"
+
+[[repo]]
+
+url = "https://github.com/shramee/dojo-shooter"
+
+[[repo]]
+
+url = "https://github.com/codekaya/Pragma-Hackathon-DOJO-ARENA"
+
+[[repo]]
+
+url = "https://github.com/FrostStarBook/CoinBubble-PragmaCairoHackathon/"
+
+[[repo]]
+
+url = "https://github.com/rkdud007/chess-dojo"
+
+[[repo]]
+
+url = "https://github.com/thiscaspar/dojo-rps"
+
+[[repo]]
+
+url = "https://github.com/cartridge-gg/beer-baron"
+
+[[repo]]
+
+url = "https://github.com/maxgiraldo/0xfaeda.git"
+
+[[repo]]
+
+url = "https://github.com/Starknopoly"
+
+[[repo]]
+
+url = "https://github.com/dpinones/wordle-dojo"
+
+[[repo]]
+
+url = "https://github.com/CollinViz/dojo-rollyouown-godot"
+
+[[repo]]
+
+url = "https://github.com/justinwangx/dojo-slot-machine"
+
+[[repo]]
+
+url = "

--- a/data/ecosystems/d/dojo-engine.toml
+++ b/data/ecosystems/d/dojo-engine.toml
@@ -1,0 +1,49 @@
+# Ecosystem Level Information
+title = "dojo-engine"
+
+sub_ecosystems = []
+
+github_organizations = ["https://github.com/dojo-engine/"]
+
+# Repositories
+[[repo]]
+url = "https://github.com/cartridge-gg/rollyourown"
+
+[[repo]]
+url = "https://github.com/BibliothecaDAO/loot-survivor"
+
+[[repo]]
+url = "https://github.com/BibliothecaDAO/eternum"
+
+[[repo]]
+url = "https://github.com/briqNFT"
+
+[[repo]]
+url = "https://github.com/influenceth"
+
+[[repo]]
+url = "https://github.com/pixelaw/"
+
+[[repo]]
+url = "https://github.com/fundaomental/underdark"
+
+[[repo]]
+url = "https://github.com/z-korp"
+
+[[repo]]
+url = "https://github.com/starklandxyz"
+
+[[repo]]
+url = "https://github.com/dojoengine/stark-lander"
+
+[[repo]]
+url = "https://github.com/cartridge-gg/drive-ai"
+
+[[repo]]
+url = "https://github.com/keep-starknet-strange/tsubasa"
+
+[[repo]]
+url = "https://github.com/ArcaneAssemblers"
+
+[[repo]]
+url = "https://github.com/0xDislands"

--- a/data/ecosystems/s/starknet.toml
+++ b/data/ecosystems/s/starknet.toml
@@ -9,6 +9,7 @@ sub_ecosystems = [
   "Braavos",
   "cartridge-gg",
   "Deth",
+  "dojo-engine"
   "EXOTHIUM",
   "Hashstack",
   "IBetYou",

--- a/data/ecosystems/s/starknet.toml
+++ b/data/ecosystems/s/starknet.toml
@@ -9,7 +9,7 @@ sub_ecosystems = [
   "Braavos",
   "cartridge-gg",
   "Deth",
-  "dojo-engine"
+  "dojo-engine,"
   "EXOTHIUM",
   "Hashstack",
   "IBetYou",

--- a/data/ecosystems/s/starknet.toml
+++ b/data/ecosystems/s/starknet.toml
@@ -9,7 +9,7 @@ sub_ecosystems = [
   "Braavos",
   "cartridge-gg",
   "Deth",
-  "dojo-engine,"
+  "dojo-engine",
   "EXOTHIUM",
   "Hashstack",
   "IBetYou",


### PR DESCRIPTION
corrected https://github.com/dojoengine/ org URL, also replaced all org/user URLs with repo URLs.