### PR TITLE
Update starknet.toml with Kiboko Offramp SDK repos

### DIFF
--- a/data/ecosystems/s/starknet.toml
+++ b/data/ecosystems/s/starknet.toml
@@ -20,7 +20,7 @@ sub_ecosystems = [
   "Hashstack",
   "IBetYou",
   "JediSwap",
-  "Kiboko Offramp"
+  "Kiboko Offramp",
   "Mint Square",
   "Nicera",
   "Node Guardians",

--- a/data/ecosystems/s/starknet.toml
+++ b/data/ecosystems/s/starknet.toml
@@ -20,6 +20,7 @@ sub_ecosystems = [
   "Hashstack",
   "IBetYou",
   "JediSwap",
+  "Kiboko Offramp"
   "Mint Square",
   "Nicera",
   "Node Guardians",
@@ -45,7 +46,8 @@ github_organizations = [
   "https://github.com/gizatechxyz",
   "https://github.com/HerodotusDev",
   "https://github.com/keep-starknet-strange",
-  "https://github.com/kkrt-labs",
+  "https://github.com/KibokoDao-Africa",
+  "https://github.com/kkrt-labs",  
   "https://github.com/starknet-edu",
   "https://github.com/starknet-io",
   "https://github.com/StarknetAstro",
@@ -4252,6 +4254,12 @@ url = "https://github.com/KholisKing/Kholison"
 url = "https://github.com/KillariDev/STARK-Combat"
 
 [[repo]]
+url = "https://github.com/KibokoDao-Africa/kiboko-offramp-contract"
+
+[[repo]]
+url = "https://github.com/KibokoDao-Africa/offrampsdk"
+
+[[repo]]
 url = "https://github.com/kirillov13/starknet-balancer"
 
 [[repo]]
@@ -7710,6 +7718,9 @@ url = "https://github.com/TimNooren/pytest-cairo"
 
 [[repo]]
 url = "https://github.com/TimNooren/starknet-compose"
+
+[[repo]]
+url = "https://github.com/timothyAgevi/offramp-client"
 
 [[repo]]
 url = "https://github.com/timothyAgevi/starknet_forge_template_sample"


### PR DESCRIPTION
Add  repositories for the Kiboko Offramp SDk,which convert cryto to mobile money and vice verse using the Starknet network.