### PR TITLE
Include Global Carbon Registry to hedera.toml

### DIFF
--- a/data/ecosystems/h/hedera.toml
+++ b/data/ecosystems/h/hedera.toml
@@ -12,6 +12,7 @@ sub_ecosystems = [
   "EasiDAO",
   "Edge",
   "EnergyTrade",
+  "Global Climate Registry",
   "HashGuild",
   "Hashport",
   "Hedera Name Service",


### PR DESCRIPTION
This pull request is to include our project names Global Carbon Registry built on top of hedera blockchain. 