### PR TITLE
Add Spark Nexus, Spark Data Service & HaloFi 

### DIFF
--- a/data/ecosystems/c/celo.toml
+++ b/data/ecosystems/c/celo.toml
@@ -18465,3 +18465,6 @@ url = "https://gitlab.com/pretoria-research-lab/celo-cauldron"
 
 [[repo]]
 url = "https://gitlab.com/pretoria-research-lab/celo-faucet-api"
+
+[[repo]]
+url = "https://github.com/Good-Ghosting/goodghosting-protocol-v2"

--- a/data/ecosystems/e/ethereum-hackathons.toml
+++ b/data/ecosystems/e/ethereum-hackathons.toml
@@ -23,3 +23,9 @@ url = "https://github.com/radiocaca/ERC721L"
 
 [[repo]]
 url = "https://github.com/xrosslend/ethnyc-submission"
+
+[[repo]]
+url = "https://github.com/Deepcryptodive/spark-nexus"
+
+[[repo]]
+url = "https://github.com/Deepcryptodive/spark-data-service"

--- a/data/ecosystems/g/gnosis-chain.toml
+++ b/data/ecosystems/g/gnosis-chain.toml
@@ -65,3 +65,9 @@ url = "https://github.com/seeinplays/gather-app"
 
 [[repo]]
 url = "https://github.com/stealthdrop/stealthdrop"
+
+[[repo]]
+url = "https://github.com/Deepcryptodive/spark-nexus"
+
+[[repo]]
+url = "https://github.com/Deepcryptodive/spark-data-service"

--- a/data/ecosystems/g/gnosis.toml
+++ b/data/ecosystems/g/gnosis.toml
@@ -1182,3 +1182,9 @@ url = "https://github.com/shrestha-roshan/evm-safe-poc"
 
 [[repo]]
 url = "https://github.com/unicef/giga_gigacounts_backend"
+
+[[repo]]
+url = "https://github.com/Deepcryptodive/spark-nexus"
+
+[[repo]]
+url = "https://github.com/Deepcryptodive/spark-data-service"

--- a/data/ecosystems/n/near.toml
+++ b/data/ecosystems/n/near.toml
@@ -33842,3 +33842,6 @@ url = "https://github.com/zuongnh/staking-contract"
 
 [[repo]]
 url = "https://github.com/zzzuhaibmohd/near-sc-security-course"
+
+[[repo]]
+url = "https://github.com/Deepcryptodive/spark-nexus"

--- a/data/ecosystems/p/polygon.toml
+++ b/data/ecosystems/p/polygon.toml
@@ -67873,3 +67873,6 @@ url = "https://github.com/Deepcryptodive/spark-nexus"
 
 [[repo]]
 url = "https://github.com/Deepcryptodive/spark-data-service"
+
+[[repo]]
+url = "https://github.com/Good-Ghosting/goodghosting-protocol-v2"

--- a/data/ecosystems/p/polygon.toml
+++ b/data/ecosystems/p/polygon.toml
@@ -67867,3 +67867,9 @@ url = "https://github.com/zzy0302/hdwyz"
 
 [[repo]]
 url = "https://github.com/zzzuhaibmohd/DeFiHackLabs"
+
+[[repo]]
+url = "https://github.com/Deepcryptodive/spark-nexus"
+
+[[repo]]
+url = "https://github.com/Deepcryptodive/spark-data-service"


### PR DESCRIPTION
This PR adds:
- [Spark Nexus](https://github.com/Deepcryptodive/spark-nexus) to Near, Gnosis, Ethereum and Polygon
- [Spark Data Service](https://github.com/Deepcryptodive/spark-data-service) to Gnosis, Ethereum and Polygon
- [HaloFi](https://github.com/Good-Ghosting/goodghosting-protocol-v2) (aka GoodGhosting v2) to Celo and Polygon 