### PR TITLE
Added Celenium Ecosystem

### DIFF
--- a/data/ecosystems/a/aevo.toml
+++ b/data/ecosystems/a/aevo.toml
@@ -1,7 +1,9 @@
 # Ecosystem Level Information
 title = "Aevo"
 
-sub_ecosystems = []
+sub_ecosystems = [
+  "Celenium",
+]
 
 github_organizations = ["https://github.com/aevoxyz"]
 

--- a/data/ecosystems/a/astria.toml
+++ b/data/ecosystems/a/astria.toml
@@ -1,7 +1,9 @@
 # Ecosystem Level Information
 title = "Astria"
 
-sub_ecosystems = []
+sub_ecosystems = [
+  "Celenium",
+]
 
 github_organizations = ["https://github.com/astriaorg"]
 

--- a/data/ecosystems/c/celenium.toml
+++ b/data/ecosystems/c/celenium.toml
@@ -1,0 +1,16 @@
+# Ecosystem Level Information
+title = "Celenium"
+
+sub_ecosystems = []
+
+github_organizations = ["https://github.com/celenium-io"]
+
+# Repositories
+[[repo]]
+url = "https://github.com/celenium-io/celenium-docs"
+
+[[repo]]
+url = "https://github.com/celenium-io/celestia-indexer"
+
+[[repo]]
+url = "https://github.com/celenium-io/celenium-interface"

--- a/data/ecosystems/c/celestia.toml
+++ b/data/ecosystems/c/celestia.toml
@@ -3,6 +3,7 @@ title = "Celestia"
 
 sub_ecosystems = [
   "Astria",
+  "Celenium",
   "dymensionxyz",
   "Eclipse",
   "Modular Cloud",

--- a/data/ecosystems/l/lyra.toml
+++ b/data/ecosystems/l/lyra.toml
@@ -1,7 +1,9 @@
 # Ecosystem Level Information
 title = "Lyra"
 
-sub_ecosystems = []
+sub_ecosystems = [
+  "Celenium",
+]
 
 github_organizations = ["https://github.com/lyra-finance"]
 

--- a/data/ecosystems/m/manta-network.toml
+++ b/data/ecosystems/m/manta-network.toml
@@ -1,7 +1,11 @@
 # Ecosystem Level Information
 title = "Manta Network"
 
-sub_ecosystems = ["Battledogs", "LayerZero"]
+sub_ecosystems = [
+  "Battledogs",
+  "Celenium",
+  "LayerZero",
+]
 
 github_organizations = ["https://github.com/Manta-Network"]
 

--- a/data/ecosystems/o/orderly-network.toml
+++ b/data/ecosystems/o/orderly-network.toml
@@ -1,7 +1,9 @@
 # Ecosystem Level Information
 title = "Orderly Network"
 
-sub_ecosystems = []
+sub_ecosystems = [
+  "Celenium",
+]
 
 github_organizations = ["https://github.com/OrderlyNetwork"]
 

--- a/data/ecosystems/p/public-goods-network.toml
+++ b/data/ecosystems/p/public-goods-network.toml
@@ -1,7 +1,10 @@
 # Ecosystem Level Information
 title = "Public Goods Network"
 
-sub_ecosystems = ["LayerZero"]
+sub_ecosystems = [
+  "Celenium",
+  "LayerZero",
+]
 
 github_organizations = ["https://github.com/supermodularxyz"]
 


### PR DESCRIPTION
Added ecosystem level information for [Celenium.io](https://celenium.io) - Blockchain Explorer for Celestia and based on it networks

Celenium.io is now a blockchain explorer that provides not just information about the Celestia network, but also insights into the broader ecosystem built around Celestia. This means you can use Celenium.io to explore not only the Celestia blockchain itself, but also the activity and data of other networks that are built on top of Celestia.