### PR TITLE
Add web3:// protocol sub-ecosystem to Ethereum.

### DIFF
--- a/data/ecosystems/w/web3-protocol.toml
+++ b/data/ecosystems/w/web3-protocol.toml
@@ -1,0 +1,28 @@
+# Ecosystem Level Information
+title = "Web3 Protocol"
+
+sub_ecosystems = []
+
+github_organizations = ["https://github.com/web3-protocol"]
+
+# Repositories
+[[repo]]
+url = "https://github.com/web3-protocol/web3curl-js"
+
+[[repo]]
+url = "https://github.com/web3-protocol/web3protocol-tests"
+
+[[repo]]
+url = "https://github.com/web3-protocol/web3protocol-go"
+
+[[repo]]
+url = "https://github.com/web3-protocol/web3protocol-js"
+
+[[repo]]
+url = "https://github.com/web3-protocol/web3protocol-sandbox"
+
+[[repo]]
+url = "https://github.com/web3-protocol/evm-browser"
+
+[[repo]]
+url = "https://github.com/ComfyGummy/chrome-web3"


### PR DESCRIPTION
The GitHub Web3 Protocol organization is home to libraries and implementations of the
[IANA-standardized `web3://` URI scheme](https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml), defined in Ethereum's [ERC-6860](https://eips.ethereum.org/EIPS/eip-6860).

This protocol puts entire website logic onchain and essentially turns an EVM chain into an execution environment for web server code.

The listed repositories include implementations of ERC-6860 client libraries, as well as a web browser extension and a Chromium fork that implements the `web3://` URI scheme.