### PR TITLE
Add eth-duties to ethereum-consensus ecosystem

### DIFF
--- a/data/ecosystems/e/ethereum-consensus.toml
+++ b/data/ecosystems/e/ethereum-consensus.toml
@@ -171,3 +171,7 @@ tags = ["Protocol"]
 [[repo]]
 url = "https://github.com/yeeth/BeaconChain.swift"
 tags = ["Protocol"]
+
+[[repo]]
+url = "https://github.com/TobiWo/eth-duties"
+tags = ["Tool"]


### PR DESCRIPTION
## Summary

Eth-duties is a tool to track validator duties in order to help you decide when to have maintenance periods for your infrastructure or your deployments so that you do not miss any important/big rewards.