### PR TITLE
chore: add swiiny/create-nextjs-dapp repo to ethereum ecosystem

### DIFF
--- a/data/ecosystems/a/arbitrum.toml
+++ b/data/ecosystems/a/arbitrum.toml
@@ -5105,9 +5105,6 @@ missing = true
 url = "https://github.com/jeremie-platz/cmonitor"
 
 [[repo]]
-url = "https://github.com/JeremyTheintz/remix-project"
-
-[[repo]]
 url = "https://github.com/jeromernandal/main-mixed-master-2"
 
 [[repo]]
@@ -9594,6 +9591,9 @@ url = "https://github.com/SwellNetwork/Pendle-Market-Deployment"
 
 [[repo]]
 url = "https://github.com/swheel33/safe-deposit"
+
+[[repo]]
+url = "https://github.com/swiiny/remix-project"
 
 [[repo]]
 url = "https://github.com/swimmiee/ethcon-korea-loanster-frontend"

--- a/data/ecosystems/o/optimism.toml
+++ b/data/ecosystems/o/optimism.toml
@@ -6634,9 +6634,6 @@ url = "https://github.com/jeonghoyeo7/V2-Public"
 url = "https://github.com/jeremie-platz/cmonitor"
 
 [[repo]]
-url = "https://github.com/JeremyTheintz/remix-project"
-
-[[repo]]
 url = "https://github.com/jeromernandal/main-mixed-master-2"
 
 [[repo]]
@@ -11593,6 +11590,9 @@ url = "https://github.com/sweetpea22/gopher-router"
 
 [[repo]]
 url = "https://github.com/swheel33/safe-deposit"
+
+[[repo]]
+url = "https://github.com/swiiny/remix-project"
 
 [[repo]]
 url = "https://github.com/swimmiee/ethcon-korea-loanster-frontend"

--- a/data/ecosystems/p/polygon.toml
+++ b/data/ecosystems/p/polygon.toml
@@ -30706,9 +30706,6 @@ url = "https://github.com/JeremyBYU/polylidar"
 url = "https://github.com/JeremyLi28/nft-transfer-market"
 
 [[repo]]
-url = "https://github.com/JeremyTheintz/poc-land"
-
-[[repo]]
 url = "https://github.com/Jericho-DAO/contracts"
 
 [[repo]]

--- a/data/ecosystems/s/starknet.toml
+++ b/data/ecosystems/s/starknet.toml
@@ -3885,9 +3885,6 @@ url = "https://github.com/Jensnicolaigustavsen/starknet"
 url = "https://github.com/jeremyjams/ZeroKnowledge"
 
 [[repo]]
-url = "https://github.com/JeremyTheintz/starknext"
-
-[[repo]]
 url = "https://github.com/Jerryjay17/Starknet-"
 
 [[repo]]


### PR DESCRIPTION
## Add new projects
- Add [Create Nextjs Dapp](https://github.com/swiiny/create-nextjs-dapp) to Ethereum ecosystem
- Add [Cryptalk](https://github.com/swiiny/cryptalk) to Ethereum ecosystem

## Remove duplicate repositories

I've noticed that some repositories were duplicated after I've updated my GitHub handle few months ago.

- [https://github.com/JeremyTheintz/create-nextjs-dapp](https://github.com/JeremyTheintz/create-nextjs-dapp) -> [https://github.com/swiiny/create-nextjs-dapp](https://github.com/swiiny/create-nextjs-dapp)
- [https://github.com/JeremyTheintz/poc-land](https://github.com/JeremyTheintz/poc-land) -> [https://github.com/swiiny/poc-land](https://github.com/swiiny/poc-land)
- [https://github.com/JeremyTheintz/remix-project](https://github.com/JeremyTheintz/remix-project) -> [https://github.com/swiiny/remix-project](https://github.com/swiiny/remix-project)