### PR TITLE
Correcting Apillon GH Org

### DIFF
--- a/data/ecosystems/a/apillon.toml
+++ b/data/ecosystems/a/apillon.toml
@@ -3,7 +3,7 @@ title = "Apillon"
 
 sub_ecosystems = []
 
-github_organizations = ["https://github.com/Apillon-web3"]
+github_organizations = ["https://github.com/Apillon-web3", "https://github.com/Apillon"]
 
 # Repositories
 [[repo]]


### PR DESCRIPTION
"https://github.com/Apillon-web3" gives 404 and I think those repos can be entirely removed. New ones under "https://github.com/Apillon" should be pulled.