### PR TITLE
add fomo_staking to radix-dlt

### DIFF
--- a/data/ecosystems/r/radix-dlt.toml
+++ b/data/ecosystems/r/radix-dlt.toml
@@ -426,3 +426,6 @@ url = "https://github.com/youngy247/scrypto-prediction-market"
 
 [[repo]]
 url = "https://github.com/youngy247/Scrypto-TokenSale-Demo"
+
+[[repo]]
+url = "https://github.com/nemster/fomo_staking/"


### PR DESCRIPTION
fomo_staking is the staking contract used by the $FOMO token on Radix DLT