### PR TITLE
Update for the new separate GitHub organization for Frequency

### DIFF
--- a/data/ecosystems/f/frequency.toml
+++ b/data/ecosystems/f/frequency.toml
@@ -3,8 +3,4 @@ title = "Frequency"
 
 sub_ecosystems = []
 
-github_organizations = []
-
-# Repositories
-[[repo]]
-url = "https://github.com/LibertyDSNP/frequency"
+github_organizations = ["https://github.com/frequency-chain/"]

--- a/data/ecosystems/p/project-liberty.toml
+++ b/data/ecosystems/p/project-liberty.toml
@@ -7,4 +7,5 @@ github_organizations = []
 
 # Repositories
 [[repo]]
-url = "https://github.com/LibertyDSNP/frequency"
+url = "https://github.com/LibertyDSNP/spec"
+tags = [ "Protocol"]


### PR DESCRIPTION
The Frequency Chain has moved to a separate GitHub organization.

- Updated the Frequency ecosystem to just have the github_organization
- Updated the Project Liberty ecosystem to just reference the Protocol: DSNP