### PR TITLE
add new stellar repos from github search results

### DIFF
--- a/data/ecosystems/s/stellar.toml
+++ b/data/ecosystems/s/stellar.toml
@@ -56,6 +56,9 @@ github_organizations = [
 
 # Repositories
 [[repo]]
+url = "https://github.com/00labs/huma-soroban-sdk"
+
+[[repo]]
 url = "https://github.com/0506CS201036/BLOCKCHAIN_BOOTCAMP"
 
 [[repo]]
@@ -83,16 +86,25 @@ url = "https://github.com/0xfe/microstellar"
 url = "https://github.com/0xKolten/stellar-asset-issuer-script"
 
 [[repo]]
+url = "https://github.com/0xScratch/First-Steps-With-Soroban"
+
+[[repo]]
 url = "https://github.com/0xtokens/awesome-blockchain"
 
 [[repo]]
 url = "https://github.com/1026957152/test"
 
 [[repo]]
+url = "https://github.com/10KD/sportCent1"
+
+[[repo]]
 url = "https://github.com/12DReflections/stellar_lumen_account_creation"
 
 [[repo]]
 url = "https://github.com/1Hr1619SxTuTBC3qYZJ1rkfAxrvWnt7bt3/stellar-rails"
+
+[[repo]]
+url = "https://github.com/5208980/soroban-snippet"
 
 [[repo]]
 url = "https://github.com/6paklata/key-recovery-service-v2"
@@ -113,7 +125,13 @@ url = "https://github.com/99nakamoto/stellar-js-sdk-example"
 url = "https://github.com/99nakamoto/velocity-lightning"
 
 [[repo]]
+url = "https://github.com/99x-incubator/smart-blog-api"
+
+[[repo]]
 url = "https://github.com/99x-incubator/smart-blog-blockchain-gateway"
+
+[[repo]]
+url = "https://github.com/99x-incubator/smart-blog-client"
 
 [[repo]]
 url = "https://github.com/A-Harby/Selenium-workflow-actions"
@@ -142,10 +160,16 @@ url = "https://github.com/aashimangla/betting-contract-aashi-gtb4cec"
 url = "https://github.com/AasmundEndresen/stellar-starter"
 
 [[repo]]
+url = "https://github.com/Abhi5415/auxilium"
+
+[[repo]]
 url = "https://github.com/AbhijitSinha1/zagg-stellar-base"
 
 [[repo]]
 url = "https://github.com/AbhijitSinha1/zagg-stellar-sdk"
+
+[[repo]]
+url = "https://github.com/AbhimanyuAjudiya/globtera"
 
 [[repo]]
 url = "https://github.com/abhinav-ireslab/Electra_App"
@@ -181,6 +205,9 @@ url = "https://github.com/abuiles/exosphere"
 url = "https://github.com/abuiles/js-stellar-canary"
 
 [[repo]]
+url = "https://github.com/abuiles/json-xdr"
+
+[[repo]]
 url = "https://github.com/acharb/go-dependency-mgmt"
 
 [[repo]]
@@ -193,7 +220,16 @@ url = "https://github.com/actionorg/js-action-base"
 url = "https://github.com/actionorg/js-action-sdk"
 
 [[repo]]
+url = "https://github.com/Adarsh-Dhar/DeBank"
+
+[[repo]]
+url = "https://github.com/Adarsh-Dhar/Hunt-a-thon-DeBank"
+
+[[repo]]
 url = "https://github.com/Adarsh-Dhar/RiseIn-Soroban-DecFree"
+
+[[repo]]
+url = "https://github.com/Adarsh-Dhar/yield-trade"
 
 [[repo]]
 url = "https://github.com/adirutwn/mint"
@@ -214,7 +250,22 @@ url = "https://github.com/Adityaakr/StellarX"
 url = "https://github.com/Adityasinha-15/subscription-contract"
 
 [[repo]]
+url = "https://github.com/aduca98/ivy_coin"
+
+[[repo]]
+url = "https://github.com/aeither/soroban-fullstack-basic"
+
+[[repo]]
 url = "https://github.com/AhaLabs/hello-world-soroban-comparison"
+
+[[repo]]
+url = "https://github.com/AhaLabs/soroban-cli-js"
+
+[[repo]]
+url = "https://github.com/AhaLabs/soroban-tutorial-project"
+
+[[repo]]
+url = "https://github.com/aiblocks/explorer"
 
 [[repo]]
 url = "https://github.com/AIDXNZ/flutter-stellar-sdk"
@@ -224,6 +275,9 @@ url = "https://github.com/AiltonSavio/cryptum-sdk"
 
 [[repo]]
 url = "https://github.com/air-protocol/chain-service"
+
+[[repo]]
+url = "https://github.com/Airswiftio/SCF"
 
 [[repo]]
 url = "https://github.com/AiTradesRepo/ATC"
@@ -256,13 +310,25 @@ url = "https://github.com/alejomendoza/stellar-nft.storage"
 url = "https://github.com/alejomendoza/stroopy"
 
 [[repo]]
+url = "https://github.com/alejomendoza/voting-poc"
+
+[[repo]]
+url = "https://github.com/Alelentini2001/fintechApp"
+
+[[repo]]
 url = "https://github.com/alex4u-a5i/stellar-app"
+
+[[repo]]
+url = "https://github.com/alexandrubujor/stellar-cli"
 
 [[repo]]
 url = "https://github.com/AlexandruPislariu/ledgerjs"
 
 [[repo]]
 url = "https://github.com/alexpro401/smart-api-js"
+
+[[repo]]
+url = "https://github.com/alexpro401/smart-base-js"
 
 [[repo]]
 url = "https://github.com/alexpro401/smart-sdk-js"
@@ -274,6 +340,9 @@ url = "https://github.com/ALFAcashier/alfacashier-api-php"
 url = "https://github.com/alien35/stellar-tutorial"
 
 [[repo]]
+url = "https://github.com/alinkon0207/Soroban_Token_Swap"
+
+[[repo]]
 url = "https://github.com/alirezavalipour/exir_front"
 
 [[repo]]
@@ -283,10 +352,31 @@ url = "https://github.com/alisvila/stellar-base"
 url = "https://github.com/alisvila/stellar-sdk"
 
 [[repo]]
+url = "https://github.com/Alkeops/It-s-not-another-package"
+
+[[repo]]
+url = "https://github.com/allbridge-io/allbridge-core-js-sdk"
+
+[[repo]]
+url = "https://github.com/allbridge-io/allbridge-core-rest-api"
+
+[[repo]]
 url = "https://github.com/allbridge-io/allbridge-core-soroban-contracts"
 
 [[repo]]
+url = "https://github.com/allbridge-io/dex-soroban-contracts"
+
+[[repo]]
+url = "https://github.com/allonsy/spectrum"
+
+[[repo]]
 url = "https://github.com/alpe/community-bifrost"
+
+[[repo]]
+url = "https://github.com/alpe/portal"
+
+[[repo]]
+url = "https://github.com/altugbakan/00c-asteroids"
 
 [[repo]]
 url = "https://github.com/altugbakan/stellar-quest-go"
@@ -297,6 +387,9 @@ missing = true
 
 [[repo]]
 url = "https://github.com/amanpanda/stellar-experiments"
+
+[[repo]]
+url = "https://github.com/ambrosus/airdao-mobile"
 
 [[repo]]
 url = "https://github.com/amelieelibh/stellar-quests"
@@ -316,6 +409,9 @@ url = "https://github.com/amissine/stellar-smart-contracts"
 
 [[repo]]
 url = "https://github.com/Amit5254/SocialMediaDapp"
+
+[[repo]]
+url = "https://github.com/Amitjang/XAlISS-SERVER"
 
 [[repo]]
 url = "https://github.com/amitjosh/StellarReads"
@@ -348,6 +444,9 @@ url = "https://github.com/andreaborio/stellarburrito"
 url = "https://github.com/andrenarchy/stellar-observatory"
 
 [[repo]]
+url = "https://github.com/andresf2448/Exchange-ProyectoFinal"
+
+[[repo]]
 url = "https://github.com/andribiz/mystellar-id"
 
 [[repo]]
@@ -355,6 +454,15 @@ url = "https://github.com/Andy92Pac/bitgo-challenge"
 
 [[repo]]
 url = "https://github.com/andyjsbell/flashback"
+
+[[repo]]
+url = "https://github.com/andyjsbell/soroban-ecs"
+
+[[repo]]
+url = "https://github.com/andywer/stellar-wallet"
+
+[[repo]]
+url = "https://github.com/andywer/zaster"
 
 [[repo]]
 url = "https://github.com/anfimovoleh/ms-users"
@@ -366,7 +474,13 @@ url = "https://github.com/AngelKey/AngelKey"
 url = "https://github.com/AngelLozan/support-explorer-ex"
 
 [[repo]]
+url = "https://github.com/AnirudhSingh07/Stellar-Health-Network-Mediconnect-"
+
+[[repo]]
 url = "https://github.com/AnkitPandram/drug-warranty"
+
+[[repo]]
+url = "https://github.com/ankitsharma0107/soro"
 
 [[repo]]
 url = "https://github.com/ankurp/fast-stellar-vanity-address-generator"
@@ -390,7 +504,16 @@ url = "https://github.com/AnneNamuli/go-stellar"
 url = "https://github.com/Ansh036/Lottery-contract-Ansh-garg--gtb4cec"
 
 [[repo]]
+url = "https://github.com/antb123/stellar-payment-api"
+
+[[repo]]
+url = "https://github.com/antb123/stellar_sep10"
+
+[[repo]]
 url = "https://github.com/antb123/stellarico"
+
+[[repo]]
+url = "https://github.com/antb123/test-rust2"
 
 [[repo]]
 url = "https://github.com/antb321/stcli"
@@ -408,7 +531,13 @@ url = "https://github.com/anuragmishra02/stellar-nodejs"
 url = "https://github.com/anurajkumarchaurasiya/blockchain"
 
 [[repo]]
+url = "https://github.com/anypay/anypay"
+
+[[repo]]
 url = "https://github.com/anypay/usdc"
+
+[[repo]]
+url = "https://github.com/anyswap/anyswap-crosschain"
 
 [[repo]]
 url = "https://github.com/aofiee/go-stellar"
@@ -426,6 +555,9 @@ url = "https://github.com/apaldiwal/stellar-quest"
 url = "https://github.com/apay-io/apay-bot"
 
 [[repo]]
+url = "https://github.com/apay-io/apay-io"
+
+[[repo]]
 url = "https://github.com/apay-io/transfer-server"
 
 [[repo]]
@@ -433,7 +565,13 @@ url = "https://github.com/apollo1130/Stellar_Dashboard_MERN"
 missing = true
 
 [[repo]]
+url = "https://github.com/AppImage/appimage.github.io"
+
+[[repo]]
 url = "https://github.com/ar-to/stellar-api"
+
+[[repo]]
+url = "https://github.com/aravind33b/pressfi"
 
 [[repo]]
 url = "https://github.com/arbach/stelien"
@@ -451,7 +589,13 @@ url = "https://github.com/Argo-Navis-Dev/anchor-reference-server"
 url = "https://github.com/Argo-Navis-Dev/php-anchor-sdk"
 
 [[repo]]
+url = "https://github.com/ariari-co/ariari-accounts-sdk"
+
+[[repo]]
 url = "https://github.com/arie-piscator/stellar-api"
+
+[[repo]]
+url = "https://github.com/aristidesstaffieri/js-xdr-test"
 
 [[repo]]
 url = "https://github.com/arjunsahu001/sotroban_bansal"
@@ -476,6 +620,9 @@ url = "https://github.com/arner/tokentool"
 url = "https://github.com/ArpitRajputGithub/rental-contract-arpit-gtb4cec"
 
 [[repo]]
+url = "https://github.com/artemlitch/sputnik"
+
+[[repo]]
 url = "https://github.com/Aryan8899/vaccine-supply-chain"
 
 [[repo]]
@@ -492,6 +639,9 @@ url = "https://github.com/ashishkumar-work/Marketplace-contract-ashish-gtb4cec"
 
 [[repo]]
 url = "https://github.com/ashrafstakala/stellar-demo-sdk"
+
+[[repo]]
+url = "https://github.com/AssemblInc/triton-desktop"
 
 [[repo]]
 url = "https://github.com/Assetsadapter/near-adapter"
@@ -533,10 +683,22 @@ url = "https://github.com/Atharv7740/payment-spliter-atharv-gtb4cec"
 url = "https://github.com/atla/loyalify"
 
 [[repo]]
+url = "https://github.com/atrokhym/monetran"
+
+[[repo]]
+url = "https://github.com/atticlab/-mobile-prostir-wallet"
+
+[[repo]]
 url = "https://github.com/atticlab/js-smart-sdk"
 
 [[repo]]
 url = "https://github.com/atticlab/smart-api-js"
+
+[[repo]]
+url = "https://github.com/attid/mtl-tools"
+
+[[repo]]
+url = "https://github.com/attid/MyMTLWalletBot"
 
 [[repo]]
 url = "https://github.com/Atul-Saxena/soroban-Birts"
@@ -566,7 +728,16 @@ url = "https://github.com/aurora-rs/xdrgen"
 url = "https://github.com/authenic-payment/AuthenticPayment"
 
 [[repo]]
+url = "https://github.com/Avento-Labs/legacy-suite-stellar"
+
+[[repo]]
 url = "https://github.com/Aviatoryona/StellarTest"
+
+[[repo]]
+url = "https://github.com/axelarnetwork/axelar-cgp-soroban"
+
+[[repo]]
+url = "https://github.com/axelarnetwork/axelar-contract-deployments"
 
 [[repo]]
 url = "https://github.com/AYCH-Inc/aych.lum.kebot"
@@ -584,6 +755,9 @@ url = "https://github.com/AYCH-Inc/aych.lum.tradeclient"
 url = "https://github.com/AYCHBIZ/Aych.android"
 
 [[repo]]
+url = "https://github.com/ayowilfred95/stellar-usdc-to-naira"
+
+[[repo]]
 url = "https://github.com/ayushsingh82/Snooker"
 
 [[repo]]
@@ -597,6 +771,9 @@ url = "https://github.com/babywind/xlm-sender"
 
 [[repo]]
 url = "https://github.com/BadzBadtz/Stellar"
+
+[[repo]]
+url = "https://github.com/bajetech/AstraX"
 
 [[repo]]
 url = "https://github.com/bajetech/stellar-dev-quickstart"
@@ -633,6 +810,9 @@ url = "https://github.com/bartekn/empty_hash_repro"
 missing = true
 
 [[repo]]
+url = "https://github.com/bartekn/stellar-cold-wallet"
+
+[[repo]]
 url = "https://github.com/Baseflow/stellar-rust-sdk"
 
 [[repo]]
@@ -663,6 +843,9 @@ url = "https://github.com/BeardKoda/stellar-tokens"
 url = "https://github.com/beeman/kin-node"
 
 [[repo]]
+url = "https://github.com/benjaminsalon/sorochat"
+
+[[repo]]
 url = "https://github.com/berberin/qrpay"
 
 [[repo]]
@@ -673,6 +856,27 @@ url = "https://github.com/beyondsun/stellar-test-exchange-demo"
 
 [[repo]]
 url = "https://github.com/Bhupendrachouhan19/Soroban-Internship-Bootcamp-Final-Project"
+
+[[repo]]
+url = "https://github.com/bigger-tech/flow"
+
+[[repo]]
+url = "https://github.com/bigger-tech/simple-stellar-signer"
+
+[[repo]]
+url = "https://github.com/bigmarh/nostrpass"
+
+[[repo]]
+url = "https://github.com/bijou-x/bijou-smart-contract-poc"
+
+[[repo]]
+url = "https://github.com/bitaccess/coinlib"
+
+[[repo]]
+url = "https://github.com/BitGo/BitGoJS"
+
+[[repo]]
+url = "https://github.com/BitGo/key-recovery-service-v2"
 
 [[repo]]
 url = "https://github.com/bjfish/stellar-core-es-indexer"
@@ -699,19 +903,34 @@ url = "https://github.com/blend-capital/blend-utils"
 url = "https://github.com/blend-capital/blend-whitepaper"
 
 [[repo]]
+url = "https://github.com/blitslabs/filecoin.loans-monorepo"
+
+[[repo]]
+url = "https://github.com/Block-Equity/desktop-wallet"
+
+[[repo]]
 url = "https://github.com/Block-Equity/stellar-android-wallet"
 
 [[repo]]
 url = "https://github.com/Block-Equity/stellar-ios-wallet"
 
 [[repo]]
+url = "https://github.com/blockchain/blockchain-wallet-v4-frontend"
+
+[[repo]]
 url = "https://github.com/blockforce-official/cryptum-sdk"
+
+[[repo]]
+url = "https://github.com/BlockImpulse/Stellar-STOCKen-CAPITAL"
 
 [[repo]]
 url = "https://github.com/blockrockettech/blockchain-transfer-tests"
 
 [[repo]]
 url = "https://github.com/blockrockettech/stellar-playground"
+
+[[repo]]
+url = "https://github.com/blockrockettech/tally-api"
 
 [[repo]]
 url = "https://github.com/BlockScience/gov-modules-demos"
@@ -795,13 +1014,37 @@ url = "https://github.com/bnogalm/StellarQtSDK"
 url = "https://github.com/bobg/scp"
 
 [[repo]]
+url = "https://github.com/Bobliuuu/DAG"
+
+[[repo]]
 url = "https://github.com/bodiam/kotlin-stellar-sdk"
+
+[[repo]]
+url = "https://github.com/bohatmx/aftarobot2019"
+
+[[repo]]
+url = "https://github.com/bohatmx/business-finance-functions"
+
+[[repo]]
+url = "https://github.com/Bond-Hive/bondExecution"
 
 [[repo]]
 url = "https://github.com/BonexIO/bonex-middleware"
 
 [[repo]]
 url = "https://github.com/bongtran/StellerConnection"
+
+[[repo]]
+url = "https://github.com/bosnet/congress-voting-desktop"
+
+[[repo]]
+url = "https://github.com/bosnet/sebakjs-sdk"
+
+[[repo]]
+url = "https://github.com/bosnet/sebakjs-util"
+
+[[repo]]
+url = "https://github.com/bosnet/wallet"
 
 [[repo]]
 url = "https://github.com/bp-ventures/lightecho-stellar-oracle"
@@ -819,6 +1062,9 @@ url = "https://github.com/bracteat/bip_utils"
 url = "https://github.com/bradiex/Lumenaid"
 
 [[repo]]
+url = "https://github.com/bresnow/xdesk_app"
+
+[[repo]]
 url = "https://github.com/brewaa/stellar-checkout"
 missing = true
 
@@ -826,7 +1072,25 @@ missing = true
 url = "https://github.com/BrianMwangi21/stellar-demo-web"
 
 [[repo]]
+url = "https://github.com/brson/fuzz-pres-code"
+
+[[repo]]
+url = "https://github.com/brson/soroban-risc0"
+
+[[repo]]
+url = "https://github.com/brson/soroban-token-fuzzer"
+
+[[repo]]
+url = "https://github.com/bruno353/accelar-frontend"
+
+[[repo]]
 url = "https://github.com/Bryan-Philip/-java-stellar-sdk"
+
+[[repo]]
+url = "https://github.com/buildlyio/stellar"
+
+[[repo]]
+url = "https://github.com/BukiOffor/multichain-wallets"
 
 [[repo]]
 url = "https://github.com/bullioncapital/js-kinesis-base"
@@ -841,6 +1105,9 @@ url = "https://github.com/bullioncapital/kinesis-horizon"
 url = "https://github.com/bunsanweb/stellar-runtime"
 
 [[repo]]
+url = "https://github.com/button-tech/blockchain-ts-wallet-core"
+
+[[repo]]
 url = "https://github.com/button-tech/utils-node-tool"
 
 [[repo]]
@@ -853,7 +1120,28 @@ url = "https://github.com/bvallelunga/crypto-research"
 url = "https://github.com/caffeinum/stellar-ico"
 
 [[repo]]
+url = "https://github.com/caffrey928/stellar_smart_contract"
+
+[[repo]]
+url = "https://github.com/candela-network/millionlumenhomepage.art"
+
+[[repo]]
 url = "https://github.com/candela-network/soroban-pixelwar"
+
+[[repo]]
+url = "https://github.com/CascadingDoomPony/PaySec"
+
+[[repo]]
+url = "https://github.com/CashAbroad/donations-contracts"
+
+[[repo]]
+url = "https://github.com/CassioMG/rn-bigint-playground"
+
+[[repo]]
+url = "https://github.com/CassioMG/rn-protocol-20-playground"
+
+[[repo]]
+url = "https://github.com/catcatio/catcat-chatbot-hotwallet"
 
 [[repo]]
 url = "https://github.com/cblanquera/blockapi"
@@ -880,6 +1168,12 @@ url = "https://github.com/CerberIco/smart-base-js"
 url = "https://github.com/CerberIco/smart-sdk-js"
 
 [[repo]]
+url = "https://github.com/chabislav/rampmedaddy"
+
+[[repo]]
+url = "https://github.com/chabislav/stellar-polaris"
+
+[[repo]]
 url = "https://github.com/ChainFront/cf-key-service"
 
 [[repo]]
@@ -901,6 +1195,9 @@ url = "https://github.com/chancity/kin-sdk-csharp"
 url = "https://github.com/chancity/kin-stellar-stats"
 
 [[repo]]
+url = "https://github.com/chancity/kinexplorer"
+
+[[repo]]
 url = "https://github.com/chancity/KinSdk"
 
 [[repo]]
@@ -908,6 +1205,9 @@ url = "https://github.com/chandresh9399/birt"
 
 [[repo]]
 url = "https://github.com/Charityhub/charitytoken"
+
+[[repo]]
+url = "https://github.com/charu-gera/playground"
 
 [[repo]]
 url = "https://github.com/chatch/mobius-app-survey"
@@ -937,7 +1237,22 @@ url = "https://github.com/chatch/xcat"
 url = "https://github.com/chattip-gee/stellar-go-api"
 
 [[repo]]
+url = "https://github.com/CheesecakeLabs/soroban-dapps"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/soroban-poc"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/sorobanathon-allowance"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/stellar-plus"
+
+[[repo]]
 url = "https://github.com/chenlihua02/ipdr-collector-go"
+
+[[repo]]
+url = "https://github.com/CHHAVIDHOTE/BU-Stellar"
 
 [[repo]]
 url = "https://github.com/chidiprime/tdscore"
@@ -966,6 +1281,9 @@ url = "https://github.com/cingireh/stellar"
 
 [[repo]]
 url = "https://github.com/circlefin/robust-tss-lib"
+
+[[repo]]
+url = "https://github.com/ckpilling/Pud-Wud"
 
 [[repo]]
 url = "https://github.com/ClickPesa/clickpesa-stellar-validator"
@@ -1001,10 +1319,34 @@ url = "https://github.com/CoderShiun/stellarTools"
 url = "https://github.com/Coding-Enthusiast/StellarCracker-NetCore"
 
 [[repo]]
+url = "https://github.com/CoinFabrik/scout-soroban"
+
+[[repo]]
+url = "https://github.com/CoinFabrik/scout-soroban-examples"
+
+[[repo]]
+url = "https://github.com/CoinSpace/cs-stellar-wallet"
+
+[[repo]]
+url = "https://github.com/Cointorox/AtomicSwapWallet"
+
+[[repo]]
 url = "https://github.com/coj337/Stablecoins_On_Stellar"
 
 [[repo]]
 url = "https://github.com/CollaborativeEconomics/give-credit"
+
+[[repo]]
+url = "https://github.com/CollaborativeEconomics/give-credits"
+
+[[repo]]
+url = "https://github.com/Colorglyph/colorglyph-soroban"
+
+[[repo]]
+url = "https://github.com/Colorglyph/colorglyph-sveltekit"
+
+[[repo]]
+url = "https://github.com/Colorglyph/colorglyph-worker"
 
 [[repo]]
 url = "https://github.com/CommuniDAO/communi-core"
@@ -1039,6 +1381,24 @@ url = "https://github.com/ConnorBlockchain/Cardiff-University-Guest-Lecture"
 
 [[repo]]
 url = "https://github.com/ConnorMac/stellar-non-fungible-factory"
+
+[[repo]]
+url = "https://github.com/constellation-protocol/constellation-protocol"
+
+[[repo]]
+url = "https://github.com/ConvexityTeam/chats-api"
+
+[[repo]]
+url = "https://github.com/CoolBitX-Technology/coolwallet-sdk"
+
+[[repo]]
+url = "https://github.com/CoolBitX-Technology/CWS-API-test"
+
+[[repo]]
+url = "https://github.com/cop1fab/dochain"
+
+[[repo]]
+url = "https://github.com/cordilleradev/karun-the-trader"
 
 [[repo]]
 url = "https://github.com/cosmic-plus/js-base"
@@ -1090,6 +1450,12 @@ url = "https://github.com/CrossChainLabs-Stellar/sorobanpulse-webapp"
 url = "https://github.com/crypdex/stellar-utils"
 
 [[repo]]
+url = "https://github.com/crypt0miester/bip39"
+
+[[repo]]
+url = "https://github.com/CryptBros/starport"
+
+[[repo]]
 url = "https://github.com/cryptobuks/tatum-php"
 
 [[repo]]
@@ -1105,22 +1471,46 @@ url = "https://github.com/CryptoLover705/Blackcoin_PiTrezor_Firmware"
 url = "https://github.com/cryptomover-software/stellar-rails-wallet"
 
 [[repo]]
+url = "https://github.com/CryptoSnap9001/CryptoSnapAPI"
+
+[[repo]]
 url = "https://github.com/cryptostorage/cryptostorage.com"
 
 [[repo]]
 url = "https://github.com/CryptoXploit/btcrecover"
 
 [[repo]]
+url = "https://github.com/cryptum-official/cryptum-sdk"
+
+[[repo]]
 url = "https://github.com/CSMDAO/trading-stellar-bot2"
 
 [[repo]]
+url = "https://github.com/cubist-labs/CubeSigner-TypeScript-SDK"
+
+[[repo]]
+url = "https://github.com/cubist-labs/cubist"
+
+[[repo]]
 url = "https://github.com/cun3yt/web3-drafts"
+
+[[repo]]
+url = "https://github.com/CyprianTinasheAarons/cross-border-remittance-application"
 
 [[repo]]
 url = "https://github.com/dabitdev/blockbill"
 
 [[repo]]
 url = "https://github.com/dadheech-vartika/She-Help"
+
+[[repo]]
+url = "https://github.com/DAIOSFoundation/d-wallet-api"
+
+[[repo]]
+url = "https://github.com/daiskipp/stellar-soroban-tutrial"
+
+[[repo]]
+url = "https://github.com/damingerdai/soroban-tutorial"
 
 [[repo]]
 url = "https://github.com/dandalion98/s-cli"
@@ -1147,13 +1537,25 @@ url = "https://github.com/danielj86/LabsStellarPOC"
 url = "https://github.com/danilomendes11/open-banking-api"
 
 [[repo]]
+url = "https://github.com/dantgw/lumenfinance"
+
+[[repo]]
+url = "https://github.com/dapixio/edge_currency_accountbased_pr"
+
+[[repo]]
 url = "https://github.com/dappstore/go-dapp"
 
 [[repo]]
 url = "https://github.com/darrylanderson/blockchain-stellar-example"
 
 [[repo]]
+url = "https://github.com/dart200/code-challange"
+
+[[repo]]
 url = "https://github.com/dart200/stellar-quest"
+
+[[repo]]
+url = "https://github.com/darthlukan/stellar-wallet"
 
 [[repo]]
 url = "https://github.com/datadef/l2.client"
@@ -1162,7 +1564,22 @@ url = "https://github.com/datadef/l2.client"
 url = "https://github.com/DAV027/Simple-Payment-System"
 
 [[repo]]
+url = "https://github.com/DavidSparker0417/setlien-contract"
+
+[[repo]]
+url = "https://github.com/DavidSparker0417/stellar-token-swap"
+
+[[repo]]
+url = "https://github.com/dbcfd/soroban-claims"
+
+[[repo]]
+url = "https://github.com/dbcfd/soroban-template"
+
+[[repo]]
 url = "https://github.com/ddombrowsky/ezegyhid"
+
+[[repo]]
+url = "https://github.com/decentappsltd/PieCard_Npm-Package"
 
 [[repo]]
 url = "https://github.com/dedis/popstellar"
@@ -1189,7 +1606,19 @@ url = "https://github.com/deep-ink-ventures/multiclique-protocol"
 url = "https://github.com/deepaklodha532/contractrust"
 
 [[repo]]
+url = "https://github.com/deepthi-1673/SPACESYNC"
+
+[[repo]]
+url = "https://github.com/definoob/first_soroban"
+
+[[repo]]
 url = "https://github.com/deimos-initiative/deimos-asset-issuer"
+
+[[repo]]
+url = "https://github.com/demining/BitGoJS-Google-Colab"
+
+[[repo]]
+url = "https://github.com/DenisStark77/roundibot"
 
 [[repo]]
 url = "https://github.com/designisO/Transactions-on-Stellar"
@@ -1220,6 +1649,9 @@ url = "https://github.com/devsolate/stellar-voting-example"
 url = "https://github.com/dexgate/merchant"
 
 [[repo]]
+url = "https://github.com/dfns/dfns-sdk-ts"
+
+[[repo]]
 url = "https://github.com/dharmendras/sorolana"
 
 [[repo]]
@@ -1229,16 +1661,40 @@ url = "https://github.com/Diamante-Net/go"
 url = "https://github.com/diamond122/s3-wasabi-vue-uploader"
 
 [[repo]]
+url = "https://github.com/didalik/dak-hex-user"
+
+[[repo]]
+url = "https://github.com/didalik/root"
+
+[[repo]]
 url = "https://github.com/didoarellano/stellar-quest"
 
 [[repo]]
+url = "https://github.com/dilan-dio4/coinlib-port"
+
+[[repo]]
+url = "https://github.com/dileepaj/tracified-nft-marketplace-frontend"
+
+[[repo]]
+url = "https://github.com/dileepaj/tracified-wallet"
+
+[[repo]]
 url = "https://github.com/divyarang24/Soroban_invoice_app"
+
+[[repo]]
+url = "https://github.com/DJ0301/Rust-Savings-Wallet"
 
 [[repo]]
 url = "https://github.com/dkf-lab/GnawBears"
 
 [[repo]]
 url = "https://github.com/dlastwishes/sample-multisig-stellar"
+
+[[repo]]
+url = "https://github.com/dlndao/Casper_ERC20"
+
+[[repo]]
+url = "https://github.com/dltxio/coin.address"
 
 [[repo]]
 url = "https://github.com/dmtrinh/stellar-utils"
@@ -1307,7 +1763,13 @@ url = "https://github.com/drashjumbo/soroban-birts"
 url = "https://github.com/Drrowly99/Stellar-Lumen-Dapp-XLM-"
 
 [[repo]]
+url = "https://github.com/drstm/orbit-cli"
+
+[[repo]]
 url = "https://github.com/dtybel/btcrecover"
+
+[[repo]]
+url = "https://github.com/DU-Crypto/jarvis-token"
 
 [[repo]]
 url = "https://github.com/DU-Crypto/stellar-quickstart"
@@ -1331,7 +1793,13 @@ url = "https://github.com/easwar1213/StellarPay-ReactJS"
 url = "https://github.com/eavelasquez/stellar-escrow"
 
 [[repo]]
+url = "https://github.com/ebarimjesus/anchor"
+
+[[repo]]
 url = "https://github.com/Ebenezerayola/Stellar-Multisig"
+
+[[repo]]
+url = "https://github.com/Ebioro/frb_test"
 
 [[repo]]
 url = "https://github.com/Ebioro/stellar-kelp"
@@ -1340,10 +1808,19 @@ url = "https://github.com/Ebioro/stellar-kelp"
 url = "https://github.com/edchainio/stellar-api"
 
 [[repo]]
+url = "https://github.com/edezekiel/stellar-wallet"
+
+[[repo]]
+url = "https://github.com/EduNodeOrg/rs-edunode-sdk"
+
+[[repo]]
 url = "https://github.com/EduNodeOrg/website"
 
 [[repo]]
 url = "https://github.com/edunuzzi/stellar-spaceship"
+
+[[repo]]
+url = "https://github.com/Edwardrem/Lynia-remittance-platform-"
 
 [[repo]]
 url = "https://github.com/ehazlett/stellar"
@@ -1368,6 +1845,9 @@ url = "https://github.com/ekmixon/trezor-firmware"
 url = "https://github.com/eldorado-Coder/stellar-app"
 
 [[repo]]
+url = "https://github.com/elfacu0/tic-tac-toe-dapp"
+
+[[repo]]
 url = "https://github.com/ElliotFriend/furry-octo-spork"
 
 [[repo]]
@@ -1377,7 +1857,16 @@ url = "https://github.com/ElliotFriend/soroban-fib-faucet"
 url = "https://github.com/ElliotFriend/sq-badge-checker"
 
 [[repo]]
+url = "https://github.com/ElliotFriend/sq-learn-scripts"
+
+[[repo]]
 url = "https://github.com/elucidsoft/dotnet-stellar-sdk"
+
+[[repo]]
+url = "https://github.com/EmanHerawy/rust-smart-contracts"
+
+[[repo]]
+url = "https://github.com/EmanHerawy/soroban-launchpad"
 
 [[repo]]
 url = "https://github.com/epappas/trading"
@@ -1392,6 +1881,15 @@ url = "https://github.com/eq-lab/slender-indexer"
 url = "https://github.com/eq-lab/slender-ui"
 
 [[repo]]
+url = "https://github.com/erenaspire7/stellar-quests"
+
+[[repo]]
+url = "https://github.com/ericcecchi/me"
+
+[[repo]]
+url = "https://github.com/ericlewis966/multichain-wallet-sdk"
+
+[[repo]]
 url = "https://github.com/ErikThiart/cryptocurrency-icons"
 
 [[repo]]
@@ -1401,16 +1899,49 @@ url = "https://github.com/ernestognw/stellar-asset-issuance"
 url = "https://github.com/ernestognw/stellar-escrow"
 
 [[repo]]
+url = "https://github.com/esteblock/donations-dapp-soroban"
+
+[[repo]]
+url = "https://github.com/esteblock/multichain-dapp"
+
+[[repo]]
+url = "https://github.com/esteblock/reentrancy-soroban"
+
+[[repo]]
 url = "https://github.com/ety001/Dogepay"
 
 [[repo]]
 url = "https://github.com/ety001/stellar-bot"
 
 [[repo]]
+url = "https://github.com/eugene3141/reflector-challenge"
+
+[[repo]]
+url = "https://github.com/Eurphus/white-hydrogen-frontend"
+
+[[repo]]
+url = "https://github.com/everlifeai/elife"
+
+[[repo]]
+url = "https://github.com/everlifeai/elife-secret"
+
+[[repo]]
 url = "https://github.com/everlifeai/eskill-proof-of-uptime"
 
 [[repo]]
+url = "https://github.com/everlifeai/everlife-community-node"
+
+[[repo]]
+url = "https://github.com/everlifeai/everlife-server-node"
+
+[[repo]]
 url = "https://github.com/everlifeai/everlife-token-sale-paymentscanner"
+
+[[repo]]
+url = "https://github.com/everlifeai/everlife-token-sale-service"
+
+[[repo]]
+url = "https://github.com/everlifeai/everlife-token-sale-webapp"
 
 [[repo]]
 url = "https://github.com/everlifeai/stellar-batch-payment-tool"
@@ -1419,10 +1950,25 @@ url = "https://github.com/everlifeai/stellar-batch-payment-tool"
 url = "https://github.com/evilpeach/stellarProject"
 
 [[repo]]
+url = "https://github.com/excellar-labs/excellar-contracts"
+
+[[repo]]
+url = "https://github.com/excellar-labs/oracle"
+
+[[repo]]
 url = "https://github.com/ExodusMovement/support-explorer"
 
 [[repo]]
+url = "https://github.com/expand-network/sdk-nodejs"
+
+[[repo]]
 url = "https://github.com/eyecandyDev/stellar-instant-transfer"
+
+[[repo]]
+url = "https://github.com/F3de420/StellarVanityGenerator"
+
+[[repo]]
+url = "https://github.com/factsfinder/Zeus"
 
 [[repo]]
 url = "https://github.com/FadhlanR/indocodex-api-master"
@@ -1467,7 +2013,25 @@ missing = true
 url = "https://github.com/fasbitX/connect-stellar_api"
 
 [[repo]]
+url = "https://github.com/fazzatti/oi-fifo-soroban-demos"
+
+[[repo]]
+url = "https://github.com/fazzatti/stellar-plus-examples"
+
+[[repo]]
+url = "https://github.com/fchainio/fireflyopen"
+
+[[repo]]
+url = "https://github.com/FcoinCrypto/api-wallet"
+
+[[repo]]
+url = "https://github.com/fdsekki/PayA_backend"
+
+[[repo]]
 url = "https://github.com/febin97/Stellar-Wallet"
+
+[[repo]]
+url = "https://github.com/fedeesti/stellar-wallet"
 
 [[repo]]
 url = "https://github.com/Fer-Bonilla/Stellar-blockchain-prototype"
@@ -1478,6 +2042,9 @@ url = "https://github.com/ferbear/myToken"
 [[repo]]
 url = "https://github.com/fernandoatrio/stellar-test"
 missing = true
+
+[[repo]]
+url = "https://github.com/ferrarif1/MyNote"
 
 [[repo]]
 url = "https://github.com/fiatjaf/debtmoney.xyz"
@@ -1498,13 +2065,34 @@ url = "https://github.com/fiersk17/F9keybase.md."
 url = "https://github.com/fiersk17/MyGeoid"
 
 [[repo]]
+url = "https://github.com/findolor/sorosplits"
+
+[[repo]]
+url = "https://github.com/findolor/sorosplits-contracts"
+
+[[repo]]
+url = "https://github.com/findolor/sorosplits-ui"
+
+[[repo]]
 url = "https://github.com/Firdausfarul/Neptunus"
+
+[[repo]]
+url = "https://github.com/Firdausfarul/NeptunusV2"
+
+[[repo]]
+url = "https://github.com/fireblocks/recovery"
 
 [[repo]]
 url = "https://github.com/fixxxedpoint/quorum_intersection"
 
 [[repo]]
+url = "https://github.com/Flame-eth/peeswap"
+
+[[repo]]
 url = "https://github.com/fleizean/StellarQuests"
+
+[[repo]]
+url = "https://github.com/floalex/tinyp2p"
 
 [[repo]]
 url = "https://github.com/fnando/lumenaddr"
@@ -1514,6 +2102,12 @@ url = "https://github.com/fnando/rn-stellar-sdk-sample"
 
 [[repo]]
 url = "https://github.com/fnando/stellar-paperwallet"
+
+[[repo]]
+url = "https://github.com/ForkingAwesome/stellock-main"
+
+[[repo]]
+url = "https://github.com/formysister/multichain-wallet-sdk"
 
 [[repo]]
 url = "https://github.com/forosuru/forosuru.github.io"
@@ -1535,10 +2129,25 @@ url = "https://github.com/francescomalatesta/awesome-stellar"
 url = "https://github.com/franzpe/hack-the-sytem"
 
 [[repo]]
+url = "https://github.com/franzpe/soroban-playground"
+
+[[repo]]
 url = "https://github.com/franzpe/stellar-quests"
 
 [[repo]]
+url = "https://github.com/FredericRezeau/soroban-kit"
+
+[[repo]]
+url = "https://github.com/FredericRezeau/soroban-oracle-example"
+
+[[repo]]
 url = "https://github.com/FredericRezeau/soroban-snooker"
+
+[[repo]]
+url = "https://github.com/FredericRezeau/tiny-soroban"
+
+[[repo]]
+url = "https://github.com/freespek/solarkraft"
 
 [[repo]]
 url = "https://github.com/froocpu/stellaR"
@@ -1549,6 +2158,15 @@ url = "https://github.com/froocpu/xlm"
 missing = true
 
 [[repo]]
+url = "https://github.com/fsodano/soroban-escrow"
+
+[[repo]]
+url = "https://github.com/fsodano/soroban-tic-tac-toe"
+
+[[repo]]
+url = "https://github.com/fukaoi/crystal-nodejs"
+
+[[repo]]
 url = "https://github.com/fukaoi/stellar-reply-server"
 missing = true
 
@@ -1557,6 +2175,12 @@ url = "https://github.com/fukaoi/stellar-suite"
 
 [[repo]]
 url = "https://github.com/fukaoi/stellar-tutorial"
+
+[[repo]]
+url = "https://github.com/functori/app-exchange"
+
+[[repo]]
+url = "https://github.com/future-tense/secret-memo"
 
 [[repo]]
 url = "https://github.com/future-tense/stargazer"
@@ -1583,13 +2207,22 @@ url = "https://github.com/future-tense/stellar-tictactoe"
 url = "https://github.com/futurnaingenieur/StellarTestJAVA"
 
 [[repo]]
+url = "https://github.com/FxDAO/FxDAO-SC"
+
+[[repo]]
 url = "https://github.com/fynio/stellar"
 
 [[repo]]
 url = "https://github.com/g-rossler/CryptoFutbol"
 
 [[repo]]
+url = "https://github.com/gabecorso/gremlin"
+
+[[repo]]
 url = "https://github.com/gabranches/stellar-arbitrage"
+
+[[repo]]
+url = "https://github.com/ganeshperson/Block-Finali"
 
 [[repo]]
 url = "https://github.com/garv720/stellar"
@@ -1601,13 +2234,31 @@ url = "https://github.com/GeekyBear/stellar-bot"
 url = "https://github.com/GeekyBear/Stellar-Hackathon"
 
 [[repo]]
+url = "https://github.com/GeekyBear/testament"
+
+[[repo]]
 url = "https://github.com/Gemstalker0871/The-Scholars"
 
 [[repo]]
 url = "https://github.com/genblue/gotree"
 
 [[repo]]
+url = "https://github.com/geofmureithi/smart-proposals"
+
+[[repo]]
 url = "https://github.com/George2Times/foregin-transfers-with-stellar"
+
+[[repo]]
+url = "https://github.com/georgeburry/stellarbot"
+
+[[repo]]
+url = "https://github.com/GetDala/toa"
+
+[[repo]]
+url = "https://github.com/gettyio/stellar-signer"
+
+[[repo]]
+url = "https://github.com/gettyio/tronwallet-notifier"
 
 [[repo]]
 url = "https://github.com/GFTN/gftn-services"
@@ -1625,6 +2276,15 @@ url = "https://github.com/giansalex/create-stellar-token"
 url = "https://github.com/giuper/Block21"
 
 [[repo]]
+url = "https://github.com/Global-Bank-of-Memories/bridge-ui"
+
+[[repo]]
+url = "https://github.com/globalchange-io/globalchange-webapp"
+
+[[repo]]
+url = "https://github.com/GM-11/frontend"
+
+[[repo]]
 url = "https://github.com/GM-11/glosoro_chat"
 
 [[repo]]
@@ -1632,6 +2292,12 @@ url = "https://github.com/gnmaxim/stellar-prototype"
 
 [[repo]]
 url = "https://github.com/go-faast/stellar-payments"
+
+[[repo]]
+url = "https://github.com/gonzamontiel/stellar-address-converter"
+
+[[repo]]
+url = "https://github.com/GoPlugin/pliblockathon_22"
 
 [[repo]]
 url = "https://github.com/goudete/stellar-playground"
@@ -1649,7 +2315,25 @@ url = "https://github.com/grievouz/hackthon-2018-mission-blockhack"
 url = "https://github.com/guardaco/stellar-hd-wallet"
 
 [[repo]]
+url = "https://github.com/gulshanpr/Soroban-hack"
+
+[[repo]]
+url = "https://github.com/gulshanpr/soroban-irl-hack"
+
+[[repo]]
 url = "https://github.com/gunstein/stellar_testing"
+
+[[repo]]
+url = "https://github.com/guplersaxanoid/stellar-subql-starter"
+
+[[repo]]
+url = "https://github.com/guudc/LumosDao"
+
+[[repo]]
+url = "https://github.com/guudc/simple-blockchain"
+
+[[repo]]
+url = "https://github.com/guudc/StellarDAO"
 
 [[repo]]
 url = "https://github.com/gyandata/npci-payment-xdr-base"
@@ -1691,6 +2375,9 @@ url = "https://github.com/hanseartic/stellar-quest"
 url = "https://github.com/hanseartic/stellar-resolve-claimant-predicates"
 
 [[repo]]
+url = "https://github.com/HappyBeautysmile/stelllar_token_connect"
+
+[[repo]]
 url = "https://github.com/hard-codr/sirius"
 
 [[repo]]
@@ -1703,6 +2390,54 @@ url = "https://github.com/HarjobandeepSingh/Soroban-Accelerated-Bootcamp-in-Indi
 url = "https://github.com/harshita-lakhchaura/Votting-soroban"
 
 [[repo]]
+url = "https://github.com/HashCash-Consultants/dashboard"
+
+[[repo]]
+url = "https://github.com/HashCash-Consultants/go"
+
+[[repo]]
+url = "https://github.com/HashCash-Consultants/go-old1"
+
+[[repo]]
+url = "https://github.com/HashCash-Consultants/rs-soroban-env"
+
+[[repo]]
+url = "https://github.com/HashCash-Consultants/rs-soroban-env-old1-20.3.0"
+
+[[repo]]
+url = "https://github.com/HashCash-Consultants/rs-soroban-env-oldd"
+
+[[repo]]
+url = "https://github.com/HashCash-Consultants/rs-soroban-sdk"
+
+[[repo]]
+url = "https://github.com/HashCash-Consultants/rs-soroban-sdk-oldd"
+
+[[repo]]
+url = "https://github.com/HashCash-Consultants/soroban-cli"
+
+[[repo]]
+url = "https://github.com/HashCash-Consultants/soroban-cli-junk"
+
+[[repo]]
+url = "https://github.com/hasToDev/cowchain-farm-soroban"
+
+[[repo]]
+url = "https://github.com/hawkingnetwork/accout-service"
+
+[[repo]]
+url = "https://github.com/hawkingnetwork/ssc"
+
+[[repo]]
+url = "https://github.com/hawthorne-abendsen/se-oracle-contract"
+
+[[repo]]
+url = "https://github.com/hawthorne-abendsen/test-contract"
+
+[[repo]]
+url = "https://github.com/hellochirag/Remitty-App"
+
+[[repo]]
 url = "https://github.com/heroletumik/hopis"
 
 [[repo]]
@@ -1710,6 +2445,24 @@ url = "https://github.com/hewigovens/go-coincodec"
 
 [[repo]]
 url = "https://github.com/hexacta/stellar-poc"
+
+[[repo]]
+url = "https://github.com/heytdep/soroban-expressions-evaluator"
+
+[[repo]]
+url = "https://github.com/heytdep/tweaked-rs-soroban-env"
+
+[[repo]]
+url = "https://github.com/heytdep/tweaked-rs-soroban-sdk"
+
+[[repo]]
+url = "https://github.com/hieuvubk/amm-admin"
+
+[[repo]]
+url = "https://github.com/hieuvubk/amm-backend"
+
+[[repo]]
+url = "https://github.com/hieuvubk/amm-fe"
 
 [[repo]]
 url = "https://github.com/hijal/stellar-demo"
@@ -1721,7 +2474,19 @@ url = "https://github.com/hijal/stellar-sep-01"
 url = "https://github.com/hijal/stellar-SEP-10"
 
 [[repo]]
+url = "https://github.com/himanshuchawla009/healthchain"
+
+[[repo]]
+url = "https://github.com/hitwill/kin-stats"
+
+[[repo]]
 url = "https://github.com/hmuehtetpaing/keybase"
+
+[[repo]]
+url = "https://github.com/HODLDeck/backend"
+
+[[repo]]
+url = "https://github.com/HonestFreak/SoroShark"
 
 [[repo]]
 url = "https://github.com/hoon4672/java-stellar-sdk"
@@ -1748,13 +2513,46 @@ url = "https://github.com/hschoenburg/stellar_utils"
 url = "https://github.com/hugorut/coins-oracle"
 
 [[repo]]
+url = "https://github.com/huitemagico/echo2"
+
+[[repo]]
+url = "https://github.com/huitemagico/kmac"
+
+[[repo]]
 url = "https://github.com/humaniq/atticlab-js-sdk"
+
+[[repo]]
+url = "https://github.com/HummingBird1224/bitcoin-private-key-validation"
 
 [[repo]]
 url = "https://github.com/HunterCan/kelp"
 
 [[repo]]
+url = "https://github.com/HunterSides/frontend"
+
+[[repo]]
 url = "https://github.com/huuquyet/basic-account-viewer"
+
+[[repo]]
+url = "https://github.com/huuquyet/rpciege-game"
+
+[[repo]]
+url = "https://github.com/huuquyet/soroban-crowdfund"
+
+[[repo]]
+url = "https://github.com/huuquyet/soroban-liquidity-pool"
+
+[[repo]]
+url = "https://github.com/huuquyet/soroban-nft-gallery"
+
+[[repo]]
+url = "https://github.com/huuquyet/soroban-oracle"
+
+[[repo]]
+url = "https://github.com/huuquyet/soroban-payment"
+
+[[repo]]
+url = "https://github.com/huuquyet/stellar-quest-solution"
 
 [[repo]]
 url = "https://github.com/huynh268/stellar-test"
@@ -1766,7 +2564,19 @@ url = "https://github.com/huyntsgs/stellar-service"
 url = "https://github.com/hybian/550"
 
 [[repo]]
+url = "https://github.com/hyperledger/solang"
+
+[[repo]]
 url = "https://github.com/iam-dev/nestjs-stellar-restapi"
+
+[[repo]]
+url = "https://github.com/IamNomadSauce/stellarnode"
+
+[[repo]]
+url = "https://github.com/iancoleman/bip39"
+
+[[repo]]
+url = "https://github.com/IanMinash/meza"
 
 [[repo]]
 url = "https://github.com/IanMinash/stellar_quests"
@@ -1775,10 +2585,19 @@ url = "https://github.com/IanMinash/stellar_quests"
 url = "https://github.com/IanMinash/stellar_quests_s2"
 
 [[repo]]
+url = "https://github.com/iartem/blockchain-integration"
+
+[[repo]]
 url = "https://github.com/ice-auror30/Distributed-Computing"
 
 [[repo]]
+url = "https://github.com/icolomina/symfony-soroban-example"
+
+[[repo]]
 url = "https://github.com/IdeaSoft-Blockchain/Zafeplace-AndroidSDK"
+
+[[repo]]
+url = "https://github.com/Ifropc/soroban-playground"
 
 [[repo]]
 url = "https://github.com/igor110055/bip_utils_test"
@@ -1788,14 +2607,32 @@ missing = true
 url = "https://github.com/IkezawaYuki/crane"
 
 [[repo]]
+url = "https://github.com/iKooruHQ/soroban_business_entity_dao"
+
+[[repo]]
 url = "https://github.com/ilesoviy/bountyhunter"
 
 [[repo]]
 url = "https://github.com/ilesoviy/soroban_token_swap_frontend"
 
 [[repo]]
+url = "https://github.com/imentus-rahul/ed25519-onchain-sign-verify"
+
+[[repo]]
+url = "https://github.com/imentus-rahul/soroban-hello-token"
+
+[[repo]]
 url = "https://github.com/imentus-rahul/stellar-ledger-poc"
 missing = true
+
+[[repo]]
+url = "https://github.com/imentus-rahul/stellar-sep10-server"
+
+[[repo]]
+url = "https://github.com/imloama/fireflywallet-chrome"
+
+[[repo]]
+url = "https://github.com/imloama/maxquant"
 
 [[repo]]
 url = "https://github.com/imloama/stellar-desktop-client"
@@ -1805,6 +2642,12 @@ url = "https://github.com/imloama/stellar-trade-bot"
 
 [[repo]]
 url = "https://github.com/inessaid/pinnacle-crypto"
+
+[[repo]]
+url = "https://github.com/InfinityWallet/infinity-chain-sdk"
+
+[[repo]]
+url = "https://github.com/InfinityWallet/infinity-core-sdk"
 
 [[repo]]
 url = "https://github.com/injaan/stellar"
@@ -1819,6 +2662,15 @@ url = "https://github.com/inspieneosols/stellar-go"
 url = "https://github.com/inspieneosols/stellar-js-stellar-sdk"
 
 [[repo]]
+url = "https://github.com/Inter-Stellar-Wallet/InterStellar-Vault"
+
+[[repo]]
+url = "https://github.com/interstellar/starlight"
+
+[[repo]]
+url = "https://github.com/intrger/sorbanDao"
+
+[[repo]]
 url = "https://github.com/iOSJedi/tatum-js"
 
 [[repo]]
@@ -1828,10 +2680,49 @@ url = "https://github.com/iov-one/blog-tutorial"
 url = "https://github.com/iov-one/weave-starter-kit"
 
 [[repo]]
+url = "https://github.com/ippontech/jbankster"
+
+[[repo]]
+url = "https://github.com/iris112/vault_server"
+
+[[repo]]
 url = "https://github.com/irisli/bookmaker"
 
 [[repo]]
 url = "https://github.com/irvingnor/anchorMX"
+
+[[repo]]
+url = "https://github.com/isabella232/step1"
+
+[[repo]]
+url = "https://github.com/isabella232/step10"
+
+[[repo]]
+url = "https://github.com/isabella232/step11"
+
+[[repo]]
+url = "https://github.com/isabella232/step13"
+
+[[repo]]
+url = "https://github.com/isabella232/step2"
+
+[[repo]]
+url = "https://github.com/isabella232/step3"
+
+[[repo]]
+url = "https://github.com/isabella232/step5"
+
+[[repo]]
+url = "https://github.com/isabella232/step6"
+
+[[repo]]
+url = "https://github.com/isabella232/step7"
+
+[[repo]]
+url = "https://github.com/isabella232/step8"
+
+[[repo]]
+url = "https://github.com/isabella232/step9"
 
 [[repo]]
 url = "https://github.com/isha-padalia/Stellar-Demo"
@@ -1841,6 +2732,9 @@ url = "https://github.com/ishankjain/domovoyServer"
 
 [[repo]]
 url = "https://github.com/ishankjena/Soroban-Dao-App"
+
+[[repo]]
+url = "https://github.com/Ishita-02/supply-chain-tracking"
 
 [[repo]]
 url = "https://github.com/iswarm/IPAE"
@@ -1873,6 +2767,15 @@ url = "https://github.com/jackyzha0/PacketBook"
 url = "https://github.com/jaglinux/stellar_marketplace"
 
 [[repo]]
+url = "https://github.com/JakeUrban/polaris-anchor-example"
+
+[[repo]]
+url = "https://github.com/jalarg/Stellar-wallet"
+
+[[repo]]
+url = "https://github.com/jamiels/ramm.ai"
+
+[[repo]]
 url = "https://github.com/jaracil/stellariumbot"
 
 [[repo]]
@@ -1880,6 +2783,12 @@ url = "https://github.com/jaspervanbrian/stellar_sdk_payments_demo"
 
 [[repo]]
 url = "https://github.com/jcamilom/ecommerce"
+
+[[repo]]
+url = "https://github.com/jeesunikim/soroban-eras-tour-nft"
+
+[[repo]]
+url = "https://github.com/jerradglenn/My-Notes"
 
 [[repo]]
 url = "https://github.com/jesmarsc/stellar3d"
@@ -1898,13 +2807,22 @@ missing = true
 url = "https://github.com/jigyasaG18/soroban-nft-smart-contract-jigyasa-gtb4cec"
 
 [[repo]]
+url = "https://github.com/JimberSoftware/stellar-crypto"
+
+[[repo]]
 url = "https://github.com/jinnerbichler/zendi"
+
+[[repo]]
+url = "https://github.com/jjjutla/melobyte"
 
 [[repo]]
 url = "https://github.com/jjuannn/stellar-fjc"
 
 [[repo]]
 url = "https://github.com/JLGGG/Stellar-Project"
+
+[[repo]]
+url = "https://github.com/jm90m/pigzbe-app"
 
 [[repo]]
 url = "https://github.com/Jmunapo/livewire-with-typescript"
@@ -1916,10 +2834,22 @@ url = "https://github.com/Jmunapo/secret-memo"
 url = "https://github.com/jnlewis/waris"
 
 [[repo]]
+url = "https://github.com/joaquinsoza/stellar-tests"
+
+[[repo]]
+url = "https://github.com/joaquinsoza/stellar-tools"
+
+[[repo]]
 url = "https://github.com/johe123qwe/github-trending"
 
 [[repo]]
+url = "https://github.com/johndpope/superlumen-gui"
+
+[[repo]]
 url = "https://github.com/johnmahlon/StellarTokenFaucet"
+
+[[repo]]
+url = "https://github.com/joincentive/backend"
 
 [[repo]]
 url = "https://github.com/jojopoper/anchor-go"
@@ -1938,6 +2868,9 @@ url = "https://github.com/Jonareid/kelp"
 
 [[repo]]
 url = "https://github.com/jonasess/Stellarswap"
+
+[[repo]]
+url = "https://github.com/Jonatan041101/Wallet-Stellar"
 
 [[repo]]
 url = "https://github.com/jonogreenz/stellar-webhooks"
@@ -1959,10 +2892,37 @@ url = "https://github.com/jpzhangvincent/nft-hot-pot"
 url = "https://github.com/julesGoullee/garnet"
 
 [[repo]]
+url = "https://github.com/Julian-dev28/Beans-merchant-sdk-react-boilerplate"
+
+[[repo]]
+url = "https://github.com/Julian-dev28/consensus-hackathon-c2defi"
+
+[[repo]]
+url = "https://github.com/Julian-dev28/Rust-Battle-Project"
+
+[[repo]]
+url = "https://github.com/Julian-dev28/soroban-multisig-dapp"
+
+[[repo]]
+url = "https://github.com/Julian-dev28/soroban-quickstart-dapp"
+
+[[repo]]
+url = "https://github.com/Julian-dev28/soroban-safe-counter"
+
+[[repo]]
+url = "https://github.com/Julian-dev28/sorovault"
+
+[[repo]]
 url = "https://github.com/julianclatro/stellar-badge-discord-bot"
 
 [[repo]]
+url = "https://github.com/JulioMCruz/PrestaFi"
+
+[[repo]]
 url = "https://github.com/jumde/stellar"
+
+[[repo]]
+url = "https://github.com/justinkgibbons89/Stellar-Wallet"
 
 [[repo]]
 url = "https://github.com/kaankacar/soroban"
@@ -1974,13 +2934,109 @@ url = "https://github.com/kadnan/RocketCommerce"
 url = "https://github.com/kaizenlabs/stellar-cli"
 
 [[repo]]
+url = "https://github.com/kalepail/boilerkit"
+
+[[repo]]
+url = "https://github.com/kalepail/buffer-woes"
+
+[[repo]]
+url = "https://github.com/kalepail/bugged-ledger-contract"
+
+[[repo]]
+url = "https://github.com/kalepail/concurrent-soroban"
+
+[[repo]]
+url = "https://github.com/kalepail/headless-turret"
+
+[[repo]]
+url = "https://github.com/kalepail/kalewalk"
+
+[[repo]]
+url = "https://github.com/kalepail/launchtube"
+
+[[repo]]
+url = "https://github.com/kalepail/m22-stellar-buzz"
+
+[[repo]]
+url = "https://github.com/kalepail/nft-stellar-buzz"
+
+[[repo]]
+url = "https://github.com/kalepail/passkey-kit"
+
+[[repo]]
+url = "https://github.com/kalepail/path-pay"
+
+[[repo]]
+url = "https://github.com/kalepail/poapplesauce"
+
+[[repo]]
+url = "https://github.com/kalepail/rollup-test"
+
+[[repo]]
+url = "https://github.com/kalepail/smol.xyz"
+
+[[repo]]
+url = "https://github.com/kalepail/soroban-authplore"
+
+[[repo]]
+url = "https://github.com/kalepail/soroban-i-like-big-budgets"
+
+[[repo]]
+url = "https://github.com/kalepail/soroban-passkey"
+
+[[repo]]
+url = "https://github.com/kalepail/sorobill"
+
+[[repo]]
+url = "https://github.com/kalepail/starlite-sveltekit"
+
+[[repo]]
+url = "https://github.com/kalepail/stellar-room-wallet"
+
+[[repo]]
+url = "https://github.com/kalepail/stellar-worker-boilerplate"
+
+[[repo]]
+url = "https://github.com/kalepail/stellarauth-serverless"
+
+[[repo]]
+url = "https://github.com/kalepail/stellarauth-webpack"
+
+[[repo]]
+url = "https://github.com/kalepail/stellarauth-webtask"
+
+[[repo]]
+url = "https://github.com/kalepail/superpeach"
+
+[[repo]]
+url = "https://github.com/kalepail/tangemsdktest"
+
+[[repo]]
+url = "https://github.com/kalepail/testnet-tools-cli"
+
+[[repo]]
+url = "https://github.com/kalepail/turing-signing-server"
+
+[[repo]]
+url = "https://github.com/kalepail/txFunction-test"
+
+[[repo]]
+url = "https://github.com/kalepail/xdr-write-error"
+
+[[repo]]
 url = "https://github.com/Kali-Decoder/Group_Travel"
+
+[[repo]]
+url = "https://github.com/Kali-Decoder/Stellpay"
 
 [[repo]]
 url = "https://github.com/KanishqVerma/soroban-tictactoe-kanishq-gtb4cec"
 
 [[repo]]
 url = "https://github.com/kannukartikeya/stellarapps"
+
+[[repo]]
+url = "https://github.com/kaotisk-hund/arching-kaos-infochain"
 
 [[repo]]
 url = "https://github.com/kaplanmaxe/colossal-stellar"
@@ -1995,6 +3051,9 @@ url = "https://github.com/karmanyaahm/payment-thing"
 url = "https://github.com/Kashvi009/subscription-contract-kashvi-gtb4cec"
 
 [[repo]]
+url = "https://github.com/kasongoyo/sdf-quick-server"
+
+[[repo]]
 url = "https://github.com/katerega/havicash"
 
 [[repo]]
@@ -2002,6 +3061,12 @@ url = "https://github.com/katopz/awesome-stellar"
 
 [[repo]]
 url = "https://github.com/katopz/poc-proof-of-existence"
+
+[[repo]]
+url = "https://github.com/kaustubh1106/zept"
+
+[[repo]]
+url = "https://github.com/keenDev4all/multichain-wallet"
 
 [[repo]]
 url = "https://github.com/ker13530018/stellar-example"
@@ -2017,6 +3082,9 @@ url = "https://github.com/keybase/client"
 
 [[repo]]
 url = "https://github.com/keybase/merkle-stellar"
+
+[[repo]]
+url = "https://github.com/keybase/node-bitcoyne"
 
 [[repo]]
 url = "https://github.com/keybase/player"
@@ -2073,6 +3141,9 @@ url = "https://github.com/Kirbyrawr/stellar-sdk-unity"
 url = "https://github.com/KirkPig/grader-blockchain"
 
 [[repo]]
+url = "https://github.com/KlaiGhassen/evaluationSysteme-prod"
+
+[[repo]]
 url = "https://github.com/klever-io/ledgerjs"
 
 [[repo]]
@@ -2110,14 +3181,32 @@ url = "https://github.com/kommitters/stellar_base"
 url = "https://github.com/kommitters/stellar_sdk"
 
 [[repo]]
+url = "https://github.com/komunitin/komunitin"
+
+[[repo]]
+url = "https://github.com/KOSASIH/CryptoQuests-StreamsideRO"
+
+[[repo]]
+url = "https://github.com/KOSASIH/pi-nexus-autonomous-banking-network"
+
+[[repo]]
+url = "https://github.com/Kosticdev0421/wallet_front-end"
+
+[[repo]]
 url = "https://github.com/krboktv/blockchain-swiss-knife"
 
 [[repo]]
 url = "https://github.com/krgko/stellar"
 
 [[repo]]
+url = "https://github.com/kshitijv256/coin_toss"
+
+[[repo]]
 url = "https://github.com/kubetrail/solkey"
 missing = true
+
+[[repo]]
+url = "https://github.com/KubixSquare/bip39KubixJS"
 
 [[repo]]
 url = "https://github.com/KuknosCo/java-keypair-sample"
@@ -2132,10 +3221,19 @@ url = "https://github.com/KuknosOrg/public-java-sdk"
 url = "https://github.com/KumanoTanaka/test-stellar"
 
 [[repo]]
+url = "https://github.com/kuyawa/givecredits"
+
+[[repo]]
 url = "https://github.com/kvreem/StellarJ"
 
 [[repo]]
 url = "https://github.com/lafronzt/stellar-federation"
+
+[[repo]]
+url = "https://github.com/laisee/XLM-tx-monitor"
+
+[[repo]]
+url = "https://github.com/lam1980/shamon"
 
 [[repo]]
 url = "https://github.com/lateralinsight2019/paystreamzwl"
@@ -2150,6 +3248,15 @@ url = "https://github.com/laxmicoinofficial/go"
 url = "https://github.com/layr-team/Layr"
 
 [[repo]]
+url = "https://github.com/LedgerHQ/app-exchange"
+
+[[repo]]
+url = "https://github.com/LedgerHQ/app-stellar"
+
+[[repo]]
+url = "https://github.com/LedgerHQ/ledger-live"
+
+[[repo]]
 url = "https://github.com/LeeSmet/find_threefold_mints"
 
 [[repo]]
@@ -2157,6 +3264,18 @@ url = "https://github.com/leighmcculloch/gravitybeam"
 
 [[repo]]
 url = "https://github.com/leighmcculloch/makenft"
+
+[[repo]]
+url = "https://github.com/leighmcculloch/soroban-base64"
+
+[[repo]]
+url = "https://github.com/leighmcculloch/soroban-fiddle"
+
+[[repo]]
+url = "https://github.com/leighmcculloch/soroban-json"
+
+[[repo]]
+url = "https://github.com/leighmcculloch/soroban-webauthn"
 
 [[repo]]
 url = "https://github.com/leighmcculloch/stellarcli"
@@ -2187,7 +3306,19 @@ missing = true
 url = "https://github.com/LightningPeach/starlight-demo-impl"
 
 [[repo]]
+url = "https://github.com/lightsail-network/contract-wasm-interface-parser"
+
+[[repo]]
+url = "https://github.com/lightsail-network/lumensigner"
+
+[[repo]]
+url = "https://github.com/lightsail-network/strledger"
+
+[[repo]]
 url = "https://github.com/lijamie98/horizon-stream-test"
+
+[[repo]]
+url = "https://github.com/limitpointinf0/pi-wallet-cli"
 
 [[repo]]
 url = "https://github.com/linguify/Soroban-Project-Risen"
@@ -2202,10 +3333,19 @@ url = "https://github.com/link-money-dev/link-app-national"
 url = "https://github.com/linkioafrica/link-stellar"
 
 [[repo]]
+url = "https://github.com/linkioafrica/ngnc-live"
+
+[[repo]]
 url = "https://github.com/linkioafrica/wavy"
 
 [[repo]]
 url = "https://github.com/linkioafrica/wavy_soroban_contract"
+
+[[repo]]
+url = "https://github.com/loambuild/frontend"
+
+[[repo]]
+url = "https://github.com/loambuild/loam-sdk"
 
 [[repo]]
 url = "https://github.com/Lobstrco/fraudulent-assets"
@@ -2229,7 +3369,19 @@ url = "https://github.com/Lobstrco/Vault-Android"
 url = "https://github.com/Lobstrco/Vault-iOS"
 
 [[repo]]
+url = "https://github.com/LoganStein/babys-first-dao"
+
+[[repo]]
 url = "https://github.com/lomkovsky/Slettar-quickstart"
+
+[[repo]]
+url = "https://github.com/luanlabs/fluxity-api"
+
+[[repo]]
+url = "https://github.com/luanlabs/fluxity-interface"
+
+[[repo]]
+url = "https://github.com/luanlabs/v1-core"
 
 [[repo]]
 url = "https://github.com/lubhub612/hedera-webservice"
@@ -2269,8 +3421,14 @@ url = "https://github.com/LukasMasuch/best-of-crypto"
 url = "https://github.com/lukaszGrynasz/stellarJobs"
 
 [[repo]]
+url = "https://github.com/lumenbox/signing-tool"
+
+[[repo]]
 url = "https://github.com/lumenocity/app"
 missing = true
+
+[[repo]]
+url = "https://github.com/Lunik/stellar-wallet-cli"
 
 [[repo]]
 url = "https://github.com/lwhz-nitish/kinesis-stellar-testing"
@@ -2299,6 +3457,9 @@ url = "https://github.com/mahansky/mystellartools"
 
 [[repo]]
 url = "https://github.com/mahansky/mystellartools-txsigner"
+
+[[repo]]
+url = "https://github.com/Mahmoud-Emad/tf-vesting"
 
 [[repo]]
 url = "https://github.com/MAJUN23/Stella"
@@ -2370,7 +3531,46 @@ url = "https://github.com/marcuskhlim/js-stellar-base"
 url = "https://github.com/marcuskhlim/tensopay"
 
 [[repo]]
+url = "https://github.com/mariusndini/awsrekplat"
+
+[[repo]]
+url = "https://github.com/mariusndini/blockchain-airline"
+
+[[repo]]
+url = "https://github.com/markuspluna/Mock-DAO-Contract"
+
+[[repo]]
+url = "https://github.com/markuspluna/seven-seas"
+
+[[repo]]
+url = "https://github.com/masonforest/quickbridge-backend"
+
+[[repo]]
+url = "https://github.com/masonforest/quickbridge-frontend"
+
+[[repo]]
+url = "https://github.com/masonforest/react-components"
+
+[[repo]]
+url = "https://github.com/masonforest/stellar-large-wasm-mvce"
+
+[[repo]]
+url = "https://github.com/masonforest/stellar.dance"
+
+[[repo]]
+url = "https://github.com/masonforest/stellereum"
+
+[[repo]]
+url = "https://github.com/masonforest/stellereum-api"
+
+[[repo]]
+url = "https://github.com/masonforest/stellereum-website"
+
+[[repo]]
 url = "https://github.com/masoud-moghini/js-kuknos-sdk"
+
+[[repo]]
+url = "https://github.com/mastermoo/stellar-wallet"
 
 [[repo]]
 url = "https://github.com/MatejMecka/hot-potato"
@@ -2380,6 +3580,24 @@ url = "https://github.com/MatejMecka/stellar-hot-potato"
 
 [[repo]]
 url = "https://github.com/MatejMecka/stellar-quest-badge-corner"
+
+[[repo]]
+url = "https://github.com/MatejMecka/Stellar-Quest-Python"
+
+[[repo]]
+url = "https://github.com/MateusZitelli/mobius-wallet"
+
+[[repo]]
+url = "https://github.com/MatHenriquez/stellar-wallet"
+
+[[repo]]
+url = "https://github.com/matjazonline/multichain-reef"
+
+[[repo]]
+url = "https://github.com/MattPoblete/SoroswapTutorial"
+
+[[repo]]
+url = "https://github.com/MattPoblete/stellar-on-ramp"
 
 [[repo]]
 url = "https://github.com/matusv/DYET"
@@ -2400,6 +3618,9 @@ url = "https://github.com/Mavennet/did-stellar-resolver"
 url = "https://github.com/maximgx/stellar-prototype"
 
 [[repo]]
+url = "https://github.com/MaximKrokhin/StellarContracts"
+
+[[repo]]
 url = "https://github.com/maxvonhippel/Stellar-Visualizer"
 
 [[repo]]
@@ -2415,10 +3636,16 @@ url = "https://github.com/mbiffara/stellarfy"
 url = "https://github.com/mbonyeemma/stellarBot"
 
 [[repo]]
+url = "https://github.com/mbuslenko/pixold-back"
+
+[[repo]]
 url = "https://github.com/mcbeav/stellar-vanity-gen"
 
 [[repo]]
 url = "https://github.com/mediocregopher/buckaroo-banzai"
+
+[[repo]]
+url = "https://github.com/MeghaBambra/seed-desktop-app"
 
 [[repo]]
 url = "https://github.com/meinharrd/stellar-helpers"
@@ -2433,6 +3660,12 @@ url = "https://github.com/mekuryGlobal/Skylar2"
 url = "https://github.com/mekuryGlobal/Skylar_Garuda"
 
 [[repo]]
+url = "https://github.com/melody-ia/tripsiamall"
+
+[[repo]]
+url = "https://github.com/meshtrade/mzar"
+
+[[repo]]
 url = "https://github.com/meta-soft-xlm/xlm-shop-api"
 
 [[repo]]
@@ -2441,6 +3674,9 @@ missing = true
 
 [[repo]]
 url = "https://github.com/meta-soft-xlm/xlm-shop-widget"
+
+[[repo]]
+url = "https://github.com/metastellar-io/metastellar-ui-lib"
 
 [[repo]]
 url = "https://github.com/methuz/stellar-hospital-token"
@@ -2461,6 +3697,9 @@ url = "https://github.com/MicaTechnology/escrow_api"
 [[repo]]
 url = "https://github.com/michael-luo/novabot"
 missing = true
+
+[[repo]]
+url = "https://github.com/michaelfioretti/cjpaymentgatewayapi"
 
 [[repo]]
 url = "https://github.com/michaelfioretti/gvtipbot"
@@ -2490,6 +3729,12 @@ url = "https://github.com/miguelmoreno/XlmAddGenBalance"
 url = "https://github.com/miguelnietoa/stellar-tutorials"
 
 [[repo]]
+url = "https://github.com/mihailtoshev/albedo"
+
+[[repo]]
+url = "https://github.com/mihailtoshev/AlbedoIntegration"
+
+[[repo]]
 url = "https://github.com/Mihir02/SorobanBootcamp_FinalProject"
 
 [[repo]]
@@ -2506,7 +3751,16 @@ missing = true
 url = "https://github.com/mimax86/stellar"
 
 [[repo]]
+url = "https://github.com/mistermoe/blockchain"
+
+[[repo]]
 url = "https://github.com/mitchelljustin/MirrorX"
+
+[[repo]]
+url = "https://github.com/Mitchzof/stratiom"
+
+[[repo]]
+url = "https://github.com/mitdralla/MyStellarWallet-AlexaSkill"
 
 [[repo]]
 url = "https://github.com/MixiP-io/smart_contracts"
@@ -2557,16 +3811,61 @@ url = "https://github.com/momerm/stellar-mining"
 url = "https://github.com/monika000000111111111/bgi1"
 
 [[repo]]
+url = "https://github.com/montelibero-org/stellar-multisig"
+
+[[repo]]
+url = "https://github.com/Montelibero/app-mtla-me"
+
+[[repo]]
+url = "https://github.com/Montelibero/mtl_solar"
+
+[[repo]]
+url = "https://github.com/MoonBite-GmbH/soroban-multisig-contracts"
+
+[[repo]]
+url = "https://github.com/moontography/blockchain-trusted-timestamping"
+
+[[repo]]
+url = "https://github.com/moontography/moontography"
+
+[[repo]]
+url = "https://github.com/mootz12/mve-map-parsing"
+
+[[repo]]
+url = "https://github.com/mootz12/mve-xdr-dependency"
+
+[[repo]]
 url = "https://github.com/mootz12/soroban-copilot"
 
 [[repo]]
+url = "https://github.com/mousebelt/mousexplore-vcoins"
+
+[[repo]]
+url = "https://github.com/mpaternostro/stellar-test-wallet"
+
+[[repo]]
 url = "https://github.com/mragiadakos/neoliberal-state-platform"
+
+[[repo]]
+url = "https://github.com/mreddychitti/stellar-apps"
+
+[[repo]]
+url = "https://github.com/msfeldstein/airdrop-script"
 
 [[repo]]
 url = "https://github.com/msfeldstein/create-stellar-token"
 
 [[repo]]
 url = "https://github.com/msfeldstein/stellar-nfts"
+
+[[repo]]
+url = "https://github.com/msfeldstein/stellar-wallet"
+
+[[repo]]
+url = "https://github.com/MSM79/StellarWallet-extension"
+
+[[repo]]
+url = "https://github.com/MszBednarski/Agitur"
 
 [[repo]]
 url = "https://github.com/mtouloup/stellar-docker-testnet"
@@ -2584,7 +3883,13 @@ url = "https://github.com/mukunzidd/ankor-api"
 url = "https://github.com/mukunzidd/stellar-network"
 
 [[repo]]
+url = "https://github.com/Mustafa-Agha/BitGoJS-bitgo-19.20.0"
+
+[[repo]]
 url = "https://github.com/mutumakeffa/stellar-team3"
+
+[[repo]]
+url = "https://github.com/MVPWorkshop/electionr-node-tools"
 
 [[repo]]
 url = "https://github.com/myklll/microstellar"
@@ -2597,6 +3902,9 @@ url = "https://github.com/mz7mz7mz7/stellar-workshop"
 
 [[repo]]
 url = "https://github.com/NachoKai/something-stellar"
+
+[[repo]]
+url = "https://github.com/nagashi/soroban-smart-contract"
 
 [[repo]]
 url = "https://github.com/Nakshatra05/SorobanChunaav"
@@ -2632,16 +3940,40 @@ url = "https://github.com/NBiLe/Alkaid-testtools"
 url = "https://github.com/NBiLe/laboratory"
 
 [[repo]]
+url = "https://github.com/ncent-archive/jobCent"
+
+[[repo]]
+url = "https://github.com/ncent-archive/ncent-SDK.js"
+
+[[repo]]
+url = "https://github.com/ncent-archive/ncent.github.io"
+
+[[repo]]
 url = "https://github.com/ncoin/stellar-sdk-test"
 
 [[repo]]
 url = "https://github.com/Neetesh17/steller_birts7"
 
 [[repo]]
+url = "https://github.com/net2devcrypto/Easy-Stellar-Soroban-JS-SDK-Functions"
+
+[[repo]]
+url = "https://github.com/net2devcrypto/Soroban-NextJS-Vote-dApp-with-Freighter"
+
+[[repo]]
+url = "https://github.com/neuralshare/node"
+
+[[repo]]
+url = "https://github.com/neutr0n420/vote-soroban"
+
+[[repo]]
 url = "https://github.com/newscrypto/stellar-integration"
 
 [[repo]]
 url = "https://github.com/NewYorkCoinNYC/pitrezor-firmware"
+
+[[repo]]
+url = "https://github.com/nexisdev/Exzo-Network-Cross-Chain-Bridge"
 
 [[repo]]
 url = "https://github.com/nfeuer/idtUnchained"
@@ -2656,6 +3988,12 @@ url = "https://github.com/ng2dev/countdown"
 url = "https://github.com/nghuyenthevinh2000/stellar-chain-asset-issuer"
 
 [[repo]]
+url = "https://github.com/nguemechieu/stellarbot"
+
+[[repo]]
+url = "https://github.com/nguyenkha/forest.network"
+
+[[repo]]
 url = "https://github.com/niawjunior/stellar-wallet-generator-api"
 
 [[repo]]
@@ -2668,6 +4006,9 @@ url = "https://github.com/nickveys/stellar-play"
 url = "https://github.com/Nicomalacho/federation-serverless"
 
 [[repo]]
+url = "https://github.com/Niftron/niftron-sdk"
+
+[[repo]]
 url = "https://github.com/Nihal-Pandey-2302/Token-Creation-and-Management"
 
 [[repo]]
@@ -2675,6 +4016,9 @@ url = "https://github.com/nikhilsaraf/stellar-downloader"
 
 [[repo]]
 url = "https://github.com/nikhilsaraf/stellar-go"
+
+[[repo]]
+url = "https://github.com/nilcons/crypto-key-derivation"
 
 [[repo]]
 url = "https://github.com/nir0812/nirnay-counter"
@@ -2687,13 +4031,25 @@ url = "https://github.com/nkoorty/Divify"
 missing = true
 
 [[repo]]
+url = "https://github.com/nkoorty/Mimoto"
+
+[[repo]]
 url = "https://github.com/nkuhero/js-action-sdk"
 
 [[repo]]
 url = "https://github.com/NNFT/nnft-inspector"
 
 [[repo]]
+url = "https://github.com/nobak-net/nobak-mobile"
+
+[[repo]]
+url = "https://github.com/Nodecafe-dev/soroban-bet-contract"
+
+[[repo]]
 url = "https://github.com/notnotrachit/lumenlock"
+
+[[repo]]
+url = "https://github.com/nrxschool/stellar-bootcamp"
 
 [[repo]]
 url = "https://github.com/ntourne/stellar-blockchain-demo"
@@ -2714,7 +4070,13 @@ url = "https://github.com/NufailIsmath/stellar-multi-signer-operation"
 url = "https://github.com/nullstyle/coinop"
 
 [[repo]]
+url = "https://github.com/nullstyle/wallet-one"
+
+[[repo]]
 url = "https://github.com/octofoxio/stress"
+
+[[repo]]
+url = "https://github.com/OctoTechHub/Opus"
 
 [[repo]]
 url = "https://github.com/OdoOdeux/soroban"
@@ -2733,6 +4095,9 @@ url = "https://github.com/oggy107/genesis-dao"
 url = "https://github.com/ohikerez/twitter-bot"
 
 [[repo]]
+url = "https://github.com/ohmygaugh-crypto/SimbaQR"
+
+[[repo]]
 url = "https://github.com/ojones/stellar-demo"
 
 [[repo]]
@@ -2747,6 +4112,9 @@ url = "https://github.com/oliverdozsa/devote-server"
 
 [[repo]]
 url = "https://github.com/oliverdozsa/galactic.host"
+
+[[repo]]
+url = "https://github.com/oliverdozsa/galactic.pub"
 
 [[repo]]
 url = "https://github.com/oluwasegunowa/securrency"
@@ -2774,6 +4142,9 @@ missing = true
 
 [[repo]]
 url = "https://github.com/OneDaijo/sbc-demo-backend"
+
+[[repo]]
+url = "https://github.com/onkr0d/transparadon"
 
 [[repo]]
 url = "https://github.com/Open-Earth-Foundation/openfinance"
@@ -2804,6 +4175,9 @@ url = "https://github.com/openMF/stellar-connector"
 url = "https://github.com/opsician/stellar-tss-boilerplate"
 
 [[repo]]
+url = "https://github.com/orbit-cdp/MaxFX"
+
+[[repo]]
 url = "https://github.com/orbitlens/Stellar-Developer-Handbook"
 
 [[repo]]
@@ -2832,6 +4206,12 @@ url = "https://github.com/orsab/stellar-payment-system"
 url = "https://github.com/orsab/z-cookies-discord"
 
 [[repo]]
+url = "https://github.com/Ortege-xyz/ortegeETL"
+
+[[repo]]
+url = "https://github.com/OrzPond/Excel-XLM-Sender"
+
+[[repo]]
 url = "https://github.com/OS-Q/S214"
 
 [[repo]]
@@ -2841,10 +4221,16 @@ url = "https://github.com/OscarKevinXR/stellar-quest-series"
 url = "https://github.com/OSCHFoundation/coast"
 
 [[repo]]
+url = "https://github.com/OSCHFoundation/js-osch-base"
+
+[[repo]]
 url = "https://github.com/oshin18/everlife-salesboxai"
 
 [[repo]]
 url = "https://github.com/OstojicI/crypto_jukebox"
+
+[[repo]]
+url = "https://github.com/otaprogramming/bnk48"
 
 [[repo]]
 url = "https://github.com/Othonna/Stellar_Smart_Contract"
@@ -2865,19 +4251,46 @@ url = "https://github.com/OutlierVentures/BlockchainDevReport"
 url = "https://github.com/overcat-deprecation/java-stellar-sdk-android-spi"
 
 [[repo]]
+url = "https://github.com/overcat/issue-1133363972670758952"
+
+[[repo]]
 url = "https://github.com/overcat/js-ledger-stellar-sdk"
 
 [[repo]]
 url = "https://github.com/overcat/ledger-stellar"
 
 [[repo]]
+url = "https://github.com/overcat/multisig-firefly"
+
+[[repo]]
+url = "https://github.com/overcat/soroban-playground-python"
+
+[[repo]]
+url = "https://github.com/overcat/stellar-key"
+
+[[repo]]
 url = "https://github.com/overcat/stellar-multisig-coordinator"
+
+[[repo]]
+url = "https://github.com/overcat/stellar-notification-bot"
+
+[[repo]]
+url = "https://github.com/overcat/stellar-quest-solutions"
 
 [[repo]]
 url = "https://github.com/OWDIN/ledgerjs"
 
 [[repo]]
 url = "https://github.com/owenkellogg/stellar-cli"
+
+[[repo]]
+url = "https://github.com/ozkavosh/stellar-wallet"
+
+[[repo]]
+url = "https://github.com/pablohpsilva/crypto-tools-sample"
+
+[[repo]]
+url = "https://github.com/PacktPublishing/Blockchain-Development-for-Finance-Projects"
 
 [[repo]]
 url = "https://github.com/pacnobi/stellar-turret-examples"
@@ -2889,6 +4302,9 @@ url = "https://github.com/pacoccino/stellar-portal"
 url = "https://github.com/pacoccino/stellar-toolkit"
 
 [[repo]]
+url = "https://github.com/pacoccino/willet"
+
+[[repo]]
 url = "https://github.com/Pactta/stellarfy"
 
 [[repo]]
@@ -2898,10 +4314,19 @@ url = "https://github.com/pakokrew/stellar-portal"
 url = "https://github.com/pakokrew/stellar-toolkit"
 
 [[repo]]
+url = "https://github.com/palinko91/soroban-merkleproof"
+
+[[repo]]
 url = "https://github.com/paoloposso/stellar-quest"
 
 [[repo]]
 url = "https://github.com/parasraut21/Subscription_Service_Soroban_Bootcamp"
+
+[[repo]]
+url = "https://github.com/pareto-xyz/tutela-app"
+
+[[repo]]
+url = "https://github.com/partner0307/Multichain-wallet-connection"
 
 [[repo]]
 url = "https://github.com/paulbellamy/stellar-wasm-demo-next"
@@ -2935,16 +4360,40 @@ url = "https://github.com/PaymentPorteORG/paymentporte-backend"
 url = "https://github.com/payshares-labs/account-viewer-v2"
 
 [[repo]]
+url = "https://github.com/payshares-labs/amm-reference-ui"
+
+[[repo]]
+url = "https://github.com/payshares-labs/auth-required-tokens-manager"
+
+[[repo]]
 url = "https://github.com/payshares-labs/convert-stellar-address"
 
 [[repo]]
 url = "https://github.com/payshares-labs/create-stellar-token"
 
 [[repo]]
+url = "https://github.com/payshares-labs/dashboard"
+
+[[repo]]
+url = "https://github.com/payshares-labs/developers"
+
+[[repo]]
+url = "https://github.com/payshares-labs/django-polaris"
+
+[[repo]]
+url = "https://github.com/payshares-labs/docs-wallet"
+
+[[repo]]
 url = "https://github.com/payshares-labs/dotnet-stellar-sdk"
 
 [[repo]]
+url = "https://github.com/payshares-labs/freighter"
+
+[[repo]]
 url = "https://github.com/payshares-labs/go"
+
+[[repo]]
+url = "https://github.com/payshares-labs/hack-stellar"
 
 [[repo]]
 url = "https://github.com/payshares-labs/java-stellar-anchor-sdk"
@@ -2959,6 +4408,15 @@ url = "https://github.com/payshares-labs/java-stellar-sdk"
 url = "https://github.com/payshares-labs/js-stellar-base"
 
 [[repo]]
+url = "https://github.com/payshares-labs/js-stellar-sdk"
+
+[[repo]]
+url = "https://github.com/payshares-labs/js-stellar-wallets"
+
+[[repo]]
+url = "https://github.com/payshares-labs/kelp"
+
+[[repo]]
 url = "https://github.com/payshares-labs/laboratory"
 
 [[repo]]
@@ -2969,6 +4427,12 @@ url = "https://github.com/payshares-labs/regulated-assets-poc"
 
 [[repo]]
 url = "https://github.com/payshares-labs/starlight"
+
+[[repo]]
+url = "https://github.com/payshares-labs/stellar-anchor-tests"
+
+[[repo]]
+url = "https://github.com/payshares-labs/stellar-demo-wallet"
 
 [[repo]]
 url = "https://github.com/payshares-labs/stellar-etl"
@@ -2995,10 +4459,22 @@ url = "https://github.com/payshares-staging/archivist"
 url = "https://github.com/payshares-staging/bifrost-js-sdk"
 
 [[repo]]
+url = "https://github.com/payshares-staging/bridge-server"
+
+[[repo]]
 url = "https://github.com/payshares-staging/convert-stellar-address"
 
 [[repo]]
+url = "https://github.com/payshares-staging/dashboard"
+
+[[repo]]
 url = "https://github.com/payshares-staging/developers"
+
+[[repo]]
+url = "https://github.com/payshares-staging/escrowgator"
+
+[[repo]]
+url = "https://github.com/payshares-staging/generator-interstellar"
 
 [[repo]]
 url = "https://github.com/payshares-staging/go"
@@ -3017,6 +4493,12 @@ url = "https://github.com/payshares-staging/interstellar-network"
 
 [[repo]]
 url = "https://github.com/payshares-staging/interstellar-network-widgets"
+
+[[repo]]
+url = "https://github.com/payshares-staging/interstellar-sessions"
+
+[[repo]]
+url = "https://github.com/payshares-staging/interstellar-wallet"
 
 [[repo]]
 url = "https://github.com/payshares-staging/java-stellar-base"
@@ -3046,6 +4528,9 @@ url = "https://github.com/payshares-staging/stellar-sms-client"
 url = "https://github.com/payshares-staging/stellar-upgrade"
 
 [[repo]]
+url = "https://github.com/payshares-staging/stellar-wallet"
+
+[[repo]]
 url = "https://github.com/payshares-staging/stellar_core_commander"
 
 [[repo]]
@@ -3067,7 +4552,28 @@ url = "https://github.com/payshares-testing/convert-stellar-address"
 url = "https://github.com/payshares-testing/create-stellar-token"
 
 [[repo]]
+url = "https://github.com/payshares-testing/dashboard"
+
+[[repo]]
+url = "https://github.com/payshares-testing/developers"
+
+[[repo]]
+url = "https://github.com/payshares-testing/django-polaris"
+
+[[repo]]
+url = "https://github.com/payshares-testing/freighter"
+
+[[repo]]
+url = "https://github.com/payshares-testing/hack-stellar"
+
+[[repo]]
 url = "https://github.com/payshares-testing/js-payshares-base"
+
+[[repo]]
+url = "https://github.com/payshares-testing/js-payshares-wallets"
+
+[[repo]]
+url = "https://github.com/payshares-testing/kelp"
 
 [[repo]]
 url = "https://github.com/payshares-testing/laboratory"
@@ -3077,6 +4583,18 @@ url = "https://github.com/payshares-testing/new-docs"
 
 [[repo]]
 url = "https://github.com/payshares-testing/regulated-assets-poc"
+
+[[repo]]
+url = "https://github.com/payshares-testing/sep24-demo-client"
+
+[[repo]]
+url = "https://github.com/payshares-testing/sep31-demo-client"
+
+[[repo]]
+url = "https://github.com/payshares-testing/sep6-demo-client"
+
+[[repo]]
+url = "https://github.com/payshares-testing/stellar-demo-wallet"
 
 [[repo]]
 url = "https://github.com/payshares-testing/stellar-etl"
@@ -3091,6 +4609,9 @@ url = "https://github.com/payshares-testing/stellar_core_commander"
 url = "https://github.com/payshares-testing/stellarterm"
 
 [[repo]]
+url = "https://github.com/payshares-testing/transfer-server-validator"
+
+[[repo]]
 url = "https://github.com/payshares/account-viewer"
 
 [[repo]]
@@ -3098,6 +4619,21 @@ url = "https://github.com/payshares/archivist"
 
 [[repo]]
 url = "https://github.com/payshares/bifrost-js-sdk"
+
+[[repo]]
+url = "https://github.com/payshares/bridge-server"
+
+[[repo]]
+url = "https://github.com/payshares/convert-payshares-address"
+
+[[repo]]
+url = "https://github.com/payshares/dashboard"
+
+[[repo]]
+url = "https://github.com/payshares/escrowgator"
+
+[[repo]]
+url = "https://github.com/payshares/generator-interpayshares"
 
 [[repo]]
 url = "https://github.com/payshares/go-payshares-base"
@@ -3110,6 +4646,9 @@ url = "https://github.com/payshares/interpayshares-network"
 
 [[repo]]
 url = "https://github.com/payshares/interpayshares-network-widgets"
+
+[[repo]]
+url = "https://github.com/payshares/interpayshares-wallet"
 
 [[repo]]
 url = "https://github.com/payshares/java-payshares-base"
@@ -3130,6 +4669,9 @@ url = "https://github.com/payshares/payshares-sms-client"
 url = "https://github.com/payshares/payshares-upgrade"
 
 [[repo]]
+url = "https://github.com/payshares/payshares-wallet"
+
+[[repo]]
 url = "https://github.com/payshares/payshares_core_commander"
 
 [[repo]]
@@ -3148,6 +4690,30 @@ url = "https://github.com/peakshift/stellar-multisig"
 url = "https://github.com/pedropablorj/SSCPayments"
 
 [[repo]]
+url = "https://github.com/pellarboss/stellarPlay"
+
+[[repo]]
+url = "https://github.com/pendulum-chain/faucet"
+
+[[repo]]
+url = "https://github.com/pendulum-chain/pendulum-squids"
+
+[[repo]]
+url = "https://github.com/pendulum-chain/pendulum-webapp"
+
+[[repo]]
+url = "https://github.com/pendulum-chain/portal"
+
+[[repo]]
+url = "https://github.com/pendulum-chain/prototypes"
+
+[[repo]]
+url = "https://github.com/pendulum-chain/scp-messages"
+
+[[repo]]
+url = "https://github.com/pendulum-chain/spacewalk-testing-service"
+
+[[repo]]
 url = "https://github.com/peng-huang-ch/blockchain-notes"
 
 [[repo]]
@@ -3157,6 +4723,9 @@ url = "https://github.com/pengpengliu/bitcorej"
 url = "https://github.com/peromaric/koios_stellar"
 
 [[repo]]
+url = "https://github.com/perun-network/perun-soroban-contract"
+
+[[repo]]
 url = "https://github.com/PeruZee/PlanetFunderInitiative"
 
 [[repo]]
@@ -3164,6 +4733,9 @@ url = "https://github.com/petetlb/xlm-testnet-faucet"
 
 [[repo]]
 url = "https://github.com/phanimukkamala2010/chainpay"
+
+[[repo]]
+url = "https://github.com/phocks/stellarbot"
 
 [[repo]]
 url = "https://github.com/Phoenix-Protocol-Group/.github"
@@ -3181,10 +4753,25 @@ url = "https://github.com/Phoenix-Protocol-Group/phoenix-indexer"
 url = "https://github.com/Phoenix-Protocol-Group/phoenix-landing"
 
 [[repo]]
+url = "https://github.com/phongho01/misc"
+
+[[repo]]
+url = "https://github.com/pi-apps/ExplorePi"
+
+[[repo]]
+url = "https://github.com/pi-apps/geraipi"
+
+[[repo]]
 url = "https://github.com/pi-apps/pi-blazor"
 
 [[repo]]
 url = "https://github.com/pi-apps/pi-csharp"
+
+[[repo]]
+url = "https://github.com/pi-apps/pi-nodejs"
+
+[[repo]]
+url = "https://github.com/pi-apps/qrcodepay"
 
 [[repo]]
 url = "https://github.com/pieterjan84/halting-analysis"
@@ -3204,6 +4791,12 @@ url = "https://github.com/PingalaSoftware/stellar-escrow-web"
 
 [[repo]]
 url = "https://github.com/platonicsocrates/payments-dapp-tutorial"
+
+[[repo]]
+url = "https://github.com/plugin-org/pliblockathon"
+
+[[repo]]
+url = "https://github.com/plugin-org/pliblockathon_22"
 
 [[repo]]
 url = "https://github.com/PlutoDAO/charon"
@@ -3242,6 +4835,9 @@ url = "https://github.com/poliha/stellar-preauth-tx"
 url = "https://github.com/poliha/stellar-tokens"
 
 [[repo]]
+url = "https://github.com/poliha/wallet.saza.io"
+
+[[repo]]
 url = "https://github.com/pomdex/pomdex"
 
 [[repo]]
@@ -3276,6 +4872,18 @@ url = "https://github.com/PriyaChandak24/insurence"
 url = "https://github.com/probably-nothing1/stellar_bank"
 
 [[repo]]
+url = "https://github.com/prodesert22/rust-merkleproof"
+
+[[repo]]
+url = "https://github.com/Programmer-Shivansh/MineChain"
+
+[[repo]]
+url = "https://github.com/programmersoham/social-checkin-dapp"
+
+[[repo]]
+url = "https://github.com/programming4phone/StellarHardwareWalletNgApp"
+
+[[repo]]
 url = "https://github.com/Protocoh/stellar_token_generator"
 
 [[repo]]
@@ -3300,10 +4908,16 @@ url = "https://github.com/qqqstuv/PeerToPeerOverlayNetwork"
 url = "https://github.com/qrius/stellar-go"
 
 [[repo]]
+url = "https://github.com/quantadex/react_quantadex"
+
+[[repo]]
 url = "https://github.com/QuantozTechnology/csharp-stellar-base"
 
 [[repo]]
 url = "https://github.com/qubicles/eos21"
+
+[[repo]]
+url = "https://github.com/quietbits/nextjs-stellar-lab-test"
 
 [[repo]]
 url = "https://github.com/Quillhash/stellar-basics"
@@ -3312,13 +4926,34 @@ url = "https://github.com/Quillhash/stellar-basics"
 url = "https://github.com/Quillhash/stellar-hyperledger-telemedicine"
 
 [[repo]]
+url = "https://github.com/quorumcontrol/policy-tree"
+
+[[repo]]
 url = "https://github.com/qwertyuiopcode/trezormirror"
+
+[[repo]]
+url = "https://github.com/r-argentina-programa/introduccion-blockchain"
+
+[[repo]]
+url = "https://github.com/r-argentina-programa/introduccion-nft"
+
+[[repo]]
+url = "https://github.com/r-argentina-programa/simple-signer-wallets-kit-demo"
+
+[[repo]]
+url = "https://github.com/Raajheer1/consensus-24"
 
 [[repo]]
 url = "https://github.com/Raene/Tonaira"
 
 [[repo]]
+url = "https://github.com/rafaalb/React-StellarLumens"
+
+[[repo]]
 url = "https://github.com/RafaelMri/stellar-java-tokengen"
+
+[[repo]]
+url = "https://github.com/rafucisneros/Stellar-Wallet"
 
 [[repo]]
 url = "https://github.com/Raghav-dvlpr/Stellar-API"
@@ -3332,6 +4967,9 @@ missing = true
 
 [[repo]]
 url = "https://github.com/rahimklaber/KotlinJs_StellarSDK"
+
+[[repo]]
+url = "https://github.com/rahimklaber/soroban_dao"
 
 [[repo]]
 url = "https://github.com/rahimklaber/soroban_hack"
@@ -3376,6 +5014,9 @@ url = "https://github.com/rahul-soshte/soroban-math"
 url = "https://github.com/rahulbirthare/soroban_BansL"
 
 [[repo]]
+url = "https://github.com/rahuldamodar94/infinity"
+
+[[repo]]
 url = "https://github.com/rahulkhedkar454/counter-BU"
 
 [[repo]]
@@ -3391,6 +5032,18 @@ url = "https://github.com/rajeshkumarbehura/stellar-blockchain"
 url = "https://github.com/ralphilius/stellar-aaas"
 
 [[repo]]
+url = "https://github.com/Rampalpanna/sorowork"
+
+[[repo]]
+url = "https://github.com/rate3-network/rate3-cross-chain"
+
+[[repo]]
+url = "https://github.com/rate3-network/rate3-monorepo"
+
+[[repo]]
+url = "https://github.com/rayauxey/blockpesa"
+
+[[repo]]
 url = "https://github.com/Razkolnikow/StellarVoteApp"
 
 [[repo]]
@@ -3398,6 +5051,9 @@ url = "https://github.com/ReactARDev/eQuidTerm"
 
 [[repo]]
 url = "https://github.com/ReDestroyDeR/etl-stellar"
+
+[[repo]]
+url = "https://github.com/Reez0/Basalt-Simple-Wallet"
 
 [[repo]]
 url = "https://github.com/refi93/stellar-chat-client"
@@ -3409,16 +5065,25 @@ url = "https://github.com/regig4/stellar"
 url = "https://github.com/reguluswallet/reguluswallet"
 
 [[repo]]
+url = "https://github.com/rehive/multisig-stellar-signer"
+
+[[repo]]
 url = "https://github.com/Reidmcc/Binance-bot"
 
 [[repo]]
 url = "https://github.com/Reidmcc/rockfish"
 
 [[repo]]
+url = "https://github.com/rektbuildr/lecce-libre"
+
+[[repo]]
 url = "https://github.com/remarcable/stellar-wind"
 
 [[repo]]
 url = "https://github.com/Rennbon/blockchainDemo"
+
+[[repo]]
+url = "https://github.com/reparadocs/AstralWallet"
 
 [[repo]]
 url = "https://github.com/revelrylabs/elixir-stellar-client"
@@ -3429,6 +5094,12 @@ url = "https://github.com/revelrylabs/exdr"
 [[repo]]
 url = "https://github.com/revelrylabs/incentivize"
 missing = true
+
+[[repo]]
+url = "https://github.com/revobrera/StellarMapWeb"
+
+[[repo]]
+url = "https://github.com/REXDEVCYBERCYBER-SECURITY/REXDEVCYBER"
 
 [[repo]]
 url = "https://github.com/rgn/stellar-playground"
@@ -3455,6 +5126,9 @@ url = "https://github.com/RiftToken/xlmKelpbotintregration"
 url = "https://github.com/ripa1993/stellarquest"
 
 [[repo]]
+url = "https://github.com/ripplefox/stellarwallet"
+
+[[repo]]
 url = "https://github.com/riti46/soroban-Birts"
 
 [[repo]]
@@ -3476,7 +5150,16 @@ url = "https://github.com/RivarolaNicolas/repayment-simulator-stellar"
 url = "https://github.com/Riyasahu0419/Blockchain"
 
 [[repo]]
+url = "https://github.com/rizamoyi/basic-payment-app"
+
+[[repo]]
+url = "https://github.com/rizamoyi/stellar-tx"
+
+[[repo]]
 url = "https://github.com/rmondalmechanical/solar"
+
+[[repo]]
+url = "https://github.com/RobEnoch/Tatum-js"
 
 [[repo]]
 url = "https://github.com/robertDurst/buzz"
@@ -3511,6 +5194,9 @@ url = "https://github.com/roeldev-deprecated-stuff/stellar-php"
 url = "https://github.com/rohankumardubey/stellar"
 
 [[repo]]
+url = "https://github.com/rohitverma007/rps-dapp"
+
+[[repo]]
 url = "https://github.com/rojasjuniore/stellar-smart-contract"
 
 [[repo]]
@@ -3530,6 +5216,12 @@ url = "https://github.com/RomanTkachenkoDistr/js-sdk"
 url = "https://github.com/RomanTkachenkoDistr/myBranchOfHorizon"
 
 [[repo]]
+url = "https://github.com/Roopshali/StellarWalletX"
+
+[[repo]]
+url = "https://github.com/Row-Bear/soroban_reverse_auction"
+
+[[repo]]
 url = "https://github.com/rpalakkal/stellar-nft"
 missing = true
 
@@ -3541,16 +5233,40 @@ missing = true
 url = "https://github.com/rubberdork/ananos-airdropper"
 
 [[repo]]
+url = "https://github.com/rvanasa/pure-webapp"
+
+[[repo]]
+url = "https://github.com/Ryang-21/Soroban-Byte-Battle"
+
+[[repo]]
 url = "https://github.com/ryanjyost/stellar-account-dashboard"
 
 [[repo]]
 url = "https://github.com/ryanleecode/stellar-anchor-server"
 
 [[repo]]
+url = "https://github.com/s-a-y/apay-be"
+
+[[repo]]
+url = "https://github.com/s-a-y/cf-sep6"
+
+[[repo]]
+url = "https://github.com/s-a-y/mass-inflation"
+
+[[repo]]
+url = "https://github.com/s-a-y/simple-trader"
+
+[[repo]]
 url = "https://github.com/s-a-y/stellar-qr"
 
 [[repo]]
 url = "https://github.com/s-a-y/stellar-sign"
+
+[[repo]]
+url = "https://github.com/s-a-y/utils"
+
+[[repo]]
+url = "https://github.com/s-alad/punch-starter"
 
 [[repo]]
 url = "https://github.com/s1q1ch4n/stellar-explorer"
@@ -3587,7 +5303,13 @@ url = "https://github.com/sachushaji/StellarToken"
 url = "https://github.com/sadiyakhan2004/Risein-Final-Project"
 
 [[repo]]
+url = "https://github.com/Sahil-Gulihar/stellar-backend"
+
+[[repo]]
 url = "https://github.com/saingsab/zeetomic-core"
+
+[[repo]]
+url = "https://github.com/sajjadium/ctf-archives"
 
 [[repo]]
 url = "https://github.com/sakshishandilya123/soroban_birt_"
@@ -3600,6 +5322,9 @@ url = "https://github.com/salavatz/stellar-sbt"
 
 [[repo]]
 url = "https://github.com/salavatz/stellar-sbt-demo"
+
+[[repo]]
+url = "https://github.com/salmonax/stello"
 
 [[repo]]
 url = "https://github.com/SALTIUM/salt-lib"
@@ -3615,7 +5340,13 @@ url = "https://github.com/samuhwai/stellar-quests-js"
 missing = true
 
 [[repo]]
+url = "https://github.com/sanathach/halving-token"
+
+[[repo]]
 url = "https://github.com/SanchitMahajan236/Soroban_Voting_Dapp"
+
+[[repo]]
+url = "https://github.com/SanderPeguero/Peliculas-by-Sander2"
 
 [[repo]]
 url = "https://github.com/sanjay882530/aurora2.21.0"
@@ -3628,6 +5359,9 @@ url = "https://github.com/sanjay882530/go20"
 
 [[repo]]
 url = "https://github.com/sanjayhashcash/go"
+
+[[repo]]
+url = "https://github.com/sanjayhashcash/rs-soroban-env-old"
 
 [[repo]]
 url = "https://github.com/sanjsingh07/kelp"
@@ -3720,7 +5454,22 @@ url = "https://github.com/script3/yieldblox-docs"
 url = "https://github.com/script3/yieldblox-docs-old"
 
 [[repo]]
+url = "https://github.com/sebamiro/increment-contract-front-template"
+
+[[repo]]
+url = "https://github.com/secure-vote/sv-lib"
+
+[[repo]]
+url = "https://github.com/SecuX/secux-js"
+
+[[repo]]
 url = "https://github.com/Sednaoui/singerbattle"
+
+[[repo]]
+url = "https://github.com/Sela-Tech/backend"
+
+[[repo]]
+url = "https://github.com/Sela-Tech/sela_mvp"
 
 [[repo]]
 url = "https://github.com/selgithub/Blockchain-AML"
@@ -3735,7 +5484,16 @@ url = "https://github.com/SergeantSerk/stellar-trading-client"
 url = "https://github.com/sergvergara/stellar"
 
 [[repo]]
+url = "https://github.com/Servant-of-the-almighty-god/BioVerse"
+
+[[repo]]
 url = "https://github.com/shah-aman/creator-x"
+
+[[repo]]
+url = "https://github.com/Shahin-kaushar/public-poll-shahin-gtb4cec."
+
+[[repo]]
+url = "https://github.com/shanekizito/stellar-nft"
 
 [[repo]]
 url = "https://github.com/shanhashcah/aurora2.12.0"
@@ -3759,10 +5517,22 @@ url = "https://github.com/shanhashcah/diamnetaurora1.11.0"
 url = "https://github.com/shanky101/StellarAlpha"
 
 [[repo]]
+url = "https://github.com/shantanu-hashcash/go"
+
+[[repo]]
+url = "https://github.com/shantanu-hashcash/rs-soroban-env"
+
+[[repo]]
+url = "https://github.com/shantanu-hashcash/rs-soroban-sdk"
+
+[[repo]]
 url = "https://github.com/shashwatadi/custom-token-stellar-android"
 
 [[repo]]
 url = "https://github.com/shawguo-cn/my-archetype"
+
+[[repo]]
+url = "https://github.com/ShehryarX/ProMotion"
 
 [[repo]]
 url = "https://github.com/Shekharlodhi/soroban-birt"
@@ -3778,7 +5548,13 @@ url = "https://github.com/sheos-org/eos21"
 url = "https://github.com/ShiningRay/stellar-sdk-types"
 
 [[repo]]
+url = "https://github.com/shivam0110/Blockchain-Transaction-API"
+
+[[repo]]
 url = "https://github.com/ShivRaiGithub/final-project-soroban"
+
+[[repo]]
+url = "https://github.com/shokworks/alfredpay-stellar-anchor"
 
 [[repo]]
 url = "https://github.com/shredding/stellar-bot"
@@ -3790,7 +5566,19 @@ url = "https://github.com/shreem-123/betting-soroban"
 url = "https://github.com/Shubham-iM/sorolana"
 
 [[repo]]
+url = "https://github.com/ShubhamPalriwala/SevenUpDown"
+
+[[repo]]
 url = "https://github.com/Shuhaib-Ahamed/DataLan"
+
+[[repo]]
+url = "https://github.com/Siddharth-2382/Birthday-Matcher"
+
+[[repo]]
+url = "https://github.com/silence48/linked-roles-bot"
+
+[[repo]]
+url = "https://github.com/silence48/SCF-Stellar-Quest-Indexer"
 
 [[repo]]
 url = "https://github.com/silence48/stellar-badge-discord-bot"
@@ -3803,10 +5591,19 @@ url = "https://github.com/silvestreh/stellar-expo-app"
 missing = true
 
 [[repo]]
+url = "https://github.com/SIMBAChain/SimbaPay"
+
+[[repo]]
 url = "https://github.com/Simerca/itpmarket"
 
 [[repo]]
 url = "https://github.com/simpleaswater/defi-resources"
+
+[[repo]]
+url = "https://github.com/SimpleHold/extension"
+
+[[repo]]
+url = "https://github.com/SIMPLYBOYS/stellar_transfer_service"
 
 [[repo]]
 url = "https://github.com/sitharaSasindu/KYD"
@@ -3814,6 +5611,9 @@ url = "https://github.com/sitharaSasindu/KYD"
 [[repo]]
 url = "https://github.com/skchang0710/npm-publish-automation-sample"
 missing = true
+
+[[repo]]
+url = "https://github.com/Skjaldbaka17/tic-tac-toe"
 
 [[repo]]
 url = "https://github.com/skyhitz/api"
@@ -3910,6 +5710,12 @@ url = "https://github.com/sldty/drop-in-fba"
 
 [[repo]]
 url = "https://github.com/slesolliec/howto-stellar"
+
+[[repo]]
+url = "https://github.com/sloanahrens/devops-toolkit-test"
+
+[[repo]]
+url = "https://github.com/SLXcoin/https-github.com-iancoleman-bip39"
 
 [[repo]]
 url = "https://github.com/slyg/stellar-multisig"
@@ -4022,13 +5828,25 @@ missing = true
 url = "https://github.com/soroswap/scf-tracker"
 
 [[repo]]
+url = "https://github.com/Sota-ThanhLe/fcx-market-maker"
+
+[[repo]]
 url = "https://github.com/Sotatek-DucPham/js-stellar-example"
+
+[[repo]]
+url = "https://github.com/Sotatek-TanNguyen2/crawler-stellar-test"
 
 [[repo]]
 url = "https://github.com/Sotatek-ThaoNguyen3/issuer-stellar"
 
 [[repo]]
 url = "https://github.com/Souvik34/Soroban-Accelerated-Bootcamp-in-India-Final-Project"
+
+[[repo]]
+url = "https://github.com/Spaceboat-Development/SpaceboatDVLP-Satellite-Contract-Prototype"
+
+[[repo]]
+url = "https://github.com/spaced-out-thoughts-dev-foundation/digicus"
 
 [[repo]]
 url = "https://github.com/SPal-14/soroban-rust"
@@ -4056,10 +5874,28 @@ url = "https://github.com/sponnusa/openbankit-smart-base-js"
 url = "https://github.com/sponnusa/openbankit-smart-sdk-js"
 
 [[repo]]
+url = "https://github.com/Spxc/expo-stellar-soroban-boilerplate"
+
+[[repo]]
+url = "https://github.com/Spxc/NodeJS_Stellar_address_monitor"
+
+[[repo]]
+url = "https://github.com/Spxc/Stellar-Asset-Rewarder"
+
+[[repo]]
+url = "https://github.com/Spxc/Stellar-blockchain-helper"
+
+[[repo]]
 url = "https://github.com/sreuland/hackaifttt"
 
 [[repo]]
+url = "https://github.com/sreuland/ifttt_demo"
+
+[[repo]]
 url = "https://github.com/SrinandanKota/DistributedSystems"
+
+[[repo]]
+url = "https://github.com/SRMannan/Soroban-Accelerated-Bootcamp-in-India-Final-Project"
 
 [[repo]]
 url = "https://github.com/SrushtiKakade28/sorobonproject"
@@ -4099,6 +5935,9 @@ url = "https://github.com/SteffenGJ/stellar-backend"
 
 [[repo]]
 url = "https://github.com/stellar-booster/browser-extension"
+
+[[repo]]
+url = "https://github.com/Stellar-Cannacoin/NodeJS_Reddit_TipBot"
 
 [[repo]]
 url = "https://github.com/Stellar-Cannacoin/StellarSDK_Federation_Validator_Util"
@@ -4354,6 +6193,12 @@ url = "https://github.com/stellar-map/stellar-map"
 
 [[repo]]
 url = "https://github.com/Stellar-Quest-Lumenauts/didactic-tribble"
+
+[[repo]]
+url = "https://github.com/Stellar-Quest-Lumenauts/fantastic-goggles"
+
+[[repo]]
+url = "https://github.com/Stellar-Quest-Lumenauts/Tip-Bot"
 
 [[repo]]
 url = "https://github.com/stellar-rocket/bank"
@@ -5003,8 +6848,17 @@ url = "https://github.com/stellarbeat/js-stellarbeat-frontend"
 url = "https://github.com/stellarburrito/stellarburritojs"
 
 [[repo]]
+url = "https://github.com/stellarcarbon/sc-audit"
+
+[[repo]]
+url = "https://github.com/stellarcarbon/sc-website"
+
+[[repo]]
 url = "https://github.com/stellarcasaW/stellarcasaW.github.io"
 missing = true
+
+[[repo]]
+url = "https://github.com/stellarchain/soroban-auditor"
 
 [[repo]]
 url = "https://github.com/stellarchat/desktop-client"
@@ -5128,10 +6982,19 @@ url = "https://github.com/stellarterm/stellarterm"
 url = "https://github.com/stellarterm/stellarterm-api"
 
 [[repo]]
+url = "https://github.com/Stogniev/CLOB-DEX-Collateral"
+
+[[repo]]
 url = "https://github.com/StroopyOrg/Stroopy"
 
 [[repo]]
+url = "https://github.com/studyToStudy/rust_contract"
+
+[[repo]]
 url = "https://github.com/stylixboom/stellar_txpacker"
+
+[[repo]]
+url = "https://github.com/subhajit11010/token-stellar"
 
 [[repo]]
 url = "https://github.com/subquery/stellar-subql-dictionaries"
@@ -5150,6 +7013,12 @@ url = "https://github.com/sui77/stellar-candyman"
 
 [[repo]]
 url = "https://github.com/sui77/stellar-sep8-example"
+
+[[repo]]
+url = "https://github.com/SUIBE-Blockchain/Super-NFT"
+
+[[repo]]
+url = "https://github.com/suman5647/WeMoveCoinsPlatform"
 
 [[repo]]
 url = "https://github.com/sumonwan/auto-parking-fee-collect-stellar"
@@ -5174,6 +7043,9 @@ url = "https://github.com/SuryaSan24x7/LoyaltyRewards_StellarBlockchain"
 
 [[repo]]
 url = "https://github.com/sushcancode/Soroban_Birts"
+
+[[repo]]
+url = "https://github.com/Swan-Finance-Inc/swan_ico"
 
 [[repo]]
 url = "https://github.com/swisscom-blockchain/stellar-demo"
@@ -5209,6 +7081,9 @@ url = "https://github.com/tamirms/soroban-events"
 url = "https://github.com/tanat1994/stellar-js-sdk-testing"
 
 [[repo]]
+url = "https://github.com/Tanishq1604/Nature-Nexus"
+
+[[repo]]
 url = "https://github.com/Tanishq1604/Nature-Nexus.git"
 missing = true
 
@@ -5238,8 +7113,17 @@ url = "https://github.com/tauruswei/WorkItemSystem"
 url = "https://github.com/TbLtzk/Centaurus"
 
 [[repo]]
+url = "https://github.com/tboydston/hdAddressGenerator"
+
+[[repo]]
+url = "https://github.com/team-fasbit/telegram"
+
+[[repo]]
 url = "https://github.com/Tech1k/trezor-firmware"
 missing = true
+
+[[repo]]
+url = "https://github.com/techmavenus/setlien_backend"
 
 [[repo]]
 url = "https://github.com/teguholica/stellar_file_e2ee"
@@ -5257,7 +7141,16 @@ url = "https://github.com/TENK-DAO/smartdeploy-example"
 url = "https://github.com/TENK-DAO/smartdeploy-frontend"
 
 [[repo]]
+url = "https://github.com/Tgemayel/pagas"
+
+[[repo]]
+url = "https://github.com/Tgemayel/stellar-wallet"
+
+[[repo]]
 url = "https://github.com/thanakritlee/stellar-playground"
+
+[[repo]]
+url = "https://github.com/thanedouglass/soroban-stellar-contracts"
 
 [[repo]]
 url = "https://github.com/the-turrets-dao/DAO-Governance-POC"
@@ -5275,19 +7168,34 @@ url = "https://github.com/thejsj/stellar-examples"
 url = "https://github.com/thekunalsaini/Stellar_Project"
 
 [[repo]]
+url = "https://github.com/TheMystic07/Green-Arrow"
+
+[[repo]]
+url = "https://github.com/TheMystic07/Green-Arrow-Final"
+
+[[repo]]
 url = "https://github.com/theproductiveprogrammer/luminate"
 
 [[repo]]
 url = "https://github.com/theproductiveprogrammer/stellar-ever-pathpayment"
 
 [[repo]]
+url = "https://github.com/thesixnetwork/six-dashboard"
+
+[[repo]]
 url = "https://github.com/thewuiz/stellar-with-nodejs"
+
+[[repo]]
+url = "https://github.com/thiagodeev/stellar-learning"
 
 [[repo]]
 url = "https://github.com/thisiskeanyvy/blocktracker"
 
 [[repo]]
 url = "https://github.com/thor1887/stellar-extended-merge"
+
+[[repo]]
+url = "https://github.com/threefoldfoundation/tft"
 
 [[repo]]
 url = "https://github.com/threefoldfoundation/tft-stellar"
@@ -5312,6 +7220,12 @@ url = "https://github.com/TinyAnvil/testnet-tools-cli"
 
 [[repo]]
 url = "https://github.com/tipbot/tipbot"
+
+[[repo]]
+url = "https://github.com/TitusEfferian/DataSehatBackEnd"
+
+[[repo]]
+url = "https://github.com/TitusEfferian/loyalty-point-apiv2"
 
 [[repo]]
 url = "https://github.com/Tjolk072/js-stellar-node-crawler-master"
@@ -5357,6 +7271,9 @@ missing = true
 url = "https://github.com/tomquisel/stellar-demo-worldbank"
 
 [[repo]]
+url = "https://github.com/toptaldev92/blockchain-wallet-v4-frontend"
+
+[[repo]]
 url = "https://github.com/TorstenStueber/scp-messages"
 
 [[repo]]
@@ -5370,6 +7287,9 @@ url = "https://github.com/TosinShada/SorobanNameService"
 
 [[repo]]
 url = "https://github.com/TosinShada/SorobanVote"
+
+[[repo]]
+url = "https://github.com/TosinShada/sorobounty-dapp"
 
 [[repo]]
 url = "https://github.com/TosinShada/stellar-core"
@@ -5387,6 +7307,9 @@ url = "https://github.com/Transak/transak-stellar"
 url = "https://github.com/TravisKinder/kelp"
 
 [[repo]]
+url = "https://github.com/trezor/trezor-suite"
+
+[[repo]]
 url = "https://github.com/triamnetwork/triam-horizon"
 
 [[repo]]
@@ -5400,6 +7323,9 @@ url = "https://github.com/Triippz/LionX"
 
 [[repo]]
 url = "https://github.com/Triippz/Lunar-Helper"
+
+[[repo]]
+url = "https://github.com/trinitronx/hypernom-soroban"
 
 [[repo]]
 url = "https://github.com/TrueKupo/cluster"
@@ -5416,16 +7342,37 @@ url = "https://github.com/truongpham710/ProjectWeb_EasyCoin"
 url = "https://github.com/trusch/stellarctl"
 
 [[repo]]
+url = "https://github.com/trustee-wallet/trusteeWallet"
+
+[[repo]]
 url = "https://github.com/ttaher/TDS"
 
 [[repo]]
+url = "https://github.com/ttvnp/ttj-asset-desktop-client"
+
+[[repo]]
 url = "https://github.com/tungdt-gem/demo-stellar"
+
+[[repo]]
+url = "https://github.com/tupui/soroban-cli-python"
+
+[[repo]]
+url = "https://github.com/tupui/soroban-pumpit"
+
+[[repo]]
+url = "https://github.com/tupui/soroban-seal-coin"
+
+[[repo]]
+url = "https://github.com/tupui/soroban-versioning"
 
 [[repo]]
 url = "https://github.com/turbo-play/elixir-stellar-sdk"
 
 [[repo]]
 url = "https://github.com/turlahector/safespace-demo"
+
+[[repo]]
+url = "https://github.com/txalo/TUSI_SEMINARIO_22"
 
 [[repo]]
 url = "https://github.com/tyler-pruitt/Robinhood-Crypto-Autotrader"
@@ -5449,13 +7396,52 @@ url = "https://github.com/UfiairENE/report"
 url = "https://github.com/ugran/Stellar-Example-Sails.Js"
 
 [[repo]]
+url = "https://github.com/UHCToken/uhx-api"
+
+[[repo]]
+url = "https://github.com/ultiledger/hd-wallet"
+
+[[repo]]
+url = "https://github.com/ultiledger/utoken"
+
+[[repo]]
+url = "https://github.com/uniibu/stellar-wallet"
+
+[[repo]]
+url = "https://github.com/UniverseBI/LuckyAddress"
+
+[[repo]]
+url = "https://github.com/uros1107/blockchain-wallet-v4-frontend"
+
+[[repo]]
 url = "https://github.com/usertxt/stellar-csv-creator"
+
+[[repo]]
+url = "https://github.com/usherlabs/stellar-transparency"
+
+[[repo]]
+url = "https://github.com/Utilitycoder/give-credit"
+
+[[repo]]
+url = "https://github.com/Utilitycoder/soro-ip"
+
+[[repo]]
+url = "https://github.com/Utilitycoder/soroban-tutorial"
+
+[[repo]]
+url = "https://github.com/valenn0101/wallet-stellar-project"
 
 [[repo]]
 url = "https://github.com/valpinkman/ledgerjs"
 
 [[repo]]
 url = "https://github.com/vamsisolasa/blockchain"
+
+[[repo]]
+url = "https://github.com/vandenhaak/whitehydrogen"
+
+[[repo]]
+url = "https://github.com/vandenhaak/whitehydrogendefi"
 
 [[repo]]
 url = "https://github.com/Varunram/essentials"
@@ -5467,16 +7453,34 @@ url = "https://github.com/Varunram/openx-cli"
 url = "https://github.com/vcarl/react-stellar"
 
 [[repo]]
+url = "https://github.com/venture-23/localcoin"
+
+[[repo]]
+url = "https://github.com/Veridise/soroban_stale_dep"
+
+[[repo]]
 url = "https://github.com/VersaraTrade/AssetIssuer"
 
 [[repo]]
 url = "https://github.com/vertiond/trezor-firmware"
 
 [[repo]]
+url = "https://github.com/Vherb/CardGame"
+
+[[repo]]
 url = "https://github.com/vidalpaul/sirius"
 
 [[repo]]
+url = "https://github.com/viktorvoltz/soroban-dev"
+
+[[repo]]
+url = "https://github.com/viktorvoltz/soroban-increment"
+
+[[repo]]
 url = "https://github.com/vinamogit/stellar-auth"
+
+[[repo]]
+url = "https://github.com/vincyf1/crypto"
 
 [[repo]]
 url = "https://github.com/vinmugambi/stellar-tutorial"
@@ -5504,6 +7508,9 @@ url = "https://github.com/vlyl/stellar-escrow-account"
 url = "https://github.com/vlyl/stellarMultiSignatureTest"
 
 [[repo]]
+url = "https://github.com/Volentix/verto"
+
+[[repo]]
 url = "https://github.com/Vuksan/stellar-research"
 
 [[repo]]
@@ -5523,7 +7530,13 @@ missing = true
 url = "https://github.com/wchopite/banodejs-stellar-basics"
 
 [[repo]]
+url = "https://github.com/webdev778/stellar-wallet"
+
+[[repo]]
 url = "https://github.com/webong/hngstellar"
+
+[[repo]]
+url = "https://github.com/whackur/lumenswap.io"
 
 [[repo]]
 url = "https://github.com/whackur/stellar-lottery"
@@ -5551,7 +7564,25 @@ url = "https://github.com/wizclass/esgcwallet"
 missing = true
 
 [[repo]]
+url = "https://github.com/WolframBlockchainLabs/WolframBridge"
+
+[[repo]]
+url = "https://github.com/woolrab6/Publicpi"
+
+[[repo]]
+url = "https://github.com/woolrab6/sturdy-bassoon"
+
+[[repo]]
+url = "https://github.com/woolrab6/upgraded-pi"
+
+[[repo]]
+url = "https://github.com/Worlddatascience/Peer-to-Peer-Payment-Application"
+
+[[repo]]
 url = "https://github.com/wxpkerpk/exchange-base-examlple"
+
+[[repo]]
+url = "https://github.com/X-oss-byte/eth"
 
 [[repo]]
 url = "https://github.com/xaviablaza/stellar-gcash-anchor-api"
@@ -5570,6 +7601,9 @@ url = "https://github.com/Xeoncross/stellar-donation-site"
 
 [[repo]]
 url = "https://github.com/xiaozhou322/powex"
+
+[[repo]]
+url = "https://github.com/xmonader/stellargui"
 
 [[repo]]
 url = "https://github.com/xNew/java-stellar-sdk-0.3.2"
@@ -5698,13 +7732,46 @@ url = "https://github.com/YaleOpenLab/openx-frontend"
 url = "https://github.com/yaseenix/CryptoStar-Dapp-pj2"
 
 [[repo]]
+url = "https://github.com/Yash-sudo-web/SorobanBootcampFinalProject"
+
+[[repo]]
 url = "https://github.com/yehiaelsayed/TransactionDiscoveryService"
+
+[[repo]]
+url = "https://github.com/yellowgh0st/etheristic"
+
+[[repo]]
+url = "https://github.com/ygolde/Eos-based-exchange"
+
+[[repo]]
+url = "https://github.com/YOGINIMAHIMA1/SOROBAN-INTERNSHIP-BOOTCAMP"
 
 [[repo]]
 url = "https://github.com/yonikashi/go"
 
 [[repo]]
+url = "https://github.com/you21979-learning/stellar"
+
+[[repo]]
+url = "https://github.com/youngqqcn/ExchangeWallet"
+
+[[repo]]
+url = "https://github.com/youngqqcn/QBlockChainNotes"
+
+[[repo]]
+url = "https://github.com/yousufkalim/soroban-smart-contract"
+
+[[repo]]
+url = "https://github.com/YouToken/bc-listener"
+
+[[repo]]
 url = "https://github.com/YudizBlockchain/Stellar-Demo"
+
+[[repo]]
+url = "https://github.com/yuesth/passkey-wallet"
+
+[[repo]]
+url = "https://github.com/yuvrajthegupta/Chat-dapp"
 
 [[repo]]
 url = "https://github.com/yuvrajthegupta/STELLARCHAT"
@@ -5725,6 +7792,9 @@ url = "https://github.com/zachdem/450-HW3"
 url = "https://github.com/ZacheryGlass/StablecoinWatch"
 
 [[repo]]
+url = "https://github.com/Zack-Xb/zapp_consensus_hack"
+
+[[repo]]
 url = "https://github.com/Zagita21/tatum-js"
 
 [[repo]]
@@ -5743,13 +7813,58 @@ url = "https://github.com/zapkub/react-distributed-ledger-workshop"
 url = "https://github.com/zapkub/stellar-private-trustline-example"
 
 [[repo]]
+url = "https://github.com/Zeemzo/blockevent-client"
+
+[[repo]]
+url = "https://github.com/Zeemzo/blockevent-explorer"
+
+[[repo]]
+url = "https://github.com/Zeemzo/blockevent-server"
+
+[[repo]]
+url = "https://github.com/Zeemzo/Blockoholics-Project1"
+
+[[repo]]
 url = "https://github.com/Zeemzo/stellar-tutorials"
+
+[[repo]]
+url = "https://github.com/Zeemzo/STOP-COVID-19-BLOCKOHOLICS"
 
 [[repo]]
 url = "https://github.com/zendi-org/django-stellar-federation"
 
 [[repo]]
+url = "https://github.com/Zettablock/stellar-temp"
+
+[[repo]]
+url = "https://github.com/zexalryz/myAfreum"
+
+[[repo]]
 url = "https://github.com/zhengyange/js-stellar-sdk"
+
+[[repo]]
+url = "https://github.com/zignartech/Ledger-Live-iota"
+
+[[repo]]
+url = "https://github.com/ZirizApp/ziriz-stellar-contract"
+
+[[repo]]
+url = "https://github.com/zkbricks/sanctum"
+
+[[repo]]
+url = "https://github.com/zklim/lumenfinance"
+
+[[repo]]
+url = "https://github.com/ZKLiquid/fUSD-token"
+
+[[repo]]
+url = "https://github.com/ZKLiquid/soroban-evm-bridge-pool"
+
+[[repo]]
+url = "https://github.com/ZKLiquid/ZKLiquid-home"
+
+[[repo]]
+url = "https://github.com/ZKLiquid/ZKLiquid-protocol"
 
 [[repo]]
 url = "https://github.com/zlucksolutions/tatum-js"
@@ -5761,7 +7876,13 @@ url = "https://github.com/zpcore/CprE-450-550-Project"
 url = "https://github.com/zthomas/metapay-chrome"
 
 [[repo]]
+url = "https://github.com/zykscode/Pieman"
+
+[[repo]]
 url = "https://github.com/zzantares/angular-stellar-issue-128"
+
+[[repo]]
+url = "https://github.com/zzigak/NFTree"
 
 [[repo]]
 url = "https://github.com/zzim2x/brave-network"


### PR DESCRIPTION
I took a bit of inspiration from another PR I saw, where a user was search for relevant SDKs declared in repo dependencies on GitHub, and adding them to an ecosystem's toml file. I've done similar, but tried to be a little more targeted than the PR I saw doing this.

The GH search I was using matched any repos with:

- `package.json` files including `stellar-sdk` or `stellar-base` as a dependency.
- `pyproject.toml` or `requirements.txt` files specifying `stellar-sdk` or `stellar_sdk` as a dependency.
- `Cargo.toml` files specifying `soroban-sdk` as a dependency.
- Weeds out any repo URLs that are already part of `stellar.toml` or any of the `stellar.toml` github orgs or sub-ecosystems.

I didn't want to search in any `yarn.lock`, etc. files, seemed like it would be way too broad of a net. That said, it still turned up a **massive** amount of repos that got added to the toml file 😬 If it's too much at once, I understand. I can turn it into a few smaller, more targeted PRs, if that works better.