### PR TITLE
add Luan labs GH org, new name for fluxitystellar

### DIFF
--- a/data/ecosystems/s/stellar.toml
+++ b/data/ecosystems/s/stellar.toml
@@ -36,6 +36,7 @@ github_organizations = [
   "https://github.com/Creit-Tech",
   "https://github.com/fairxio",
   "https://github.com/Lobstrco",
+  "https://github.com/luanlabs",
   "https://github.com/okashi-dev",
   "https://github.com/Phoenix-Protocol-Group",
   "https://github.com/PlutoDAO",

--- a/data/ecosystems/s/stellar.toml
+++ b/data/ecosystems/s/stellar.toml
@@ -3382,7 +3382,22 @@ url = "https://github.com/luanlabs/fluxity-api"
 url = "https://github.com/luanlabs/fluxity-interface"
 
 [[repo]]
+url = "https://github.com/luanlabs/fluxity.finance"
+
+[[repo]]
 url = "https://github.com/luanlabs/v1-core"
+
+[[repo]]
+url = "https://github.com/luanlabs/wagent-interface"
+
+[[repo]]
+url = "https://github.com/luanlabs/wagent-payment"
+
+[[repo]]
+url = "https://github.com/luanlabs/wagent-payment-api"
+
+[[repo]]
+url = "https://github.com/luanlabs/wagent-proxy-contract"
 
 [[repo]]
 url = "https://github.com/lubhub612/hedera-webservice"


### PR DESCRIPTION
Previously, our `stellar.toml` file included the `fluxitystellar` GH org, which appears to have been renamed or folded into the `luanlabs` GH org. `fluxitystellar` was removed in 78025b3a85220a93b653ada9e029df010d8ecfaf. This PR adds the new org to the `stellar.toml` file.

> _Note:_ I'm well aware that we're past the deadline for the midyear update, and I have no expectations that this change would be included/reflected in that midyear data. Just trying to keep things up-to-date moving forward.