### PR TITLE
Add Cheesecake Labs as a sub-ecosystem of Stellar

### DIFF
--- a/data/ecosystems/c/cheesecake-labs.toml
+++ b/data/ecosystems/c/cheesecake-labs.toml
@@ -1,0 +1,274 @@
+# Ecosystem Level Information
+title = "Cheesecake Labs"
+
+sub_ecosystems = []
+
+github_organizations = ["https://github.com/CheesecakeLabs"]
+
+# Repositories
+[[repo]]
+url = "https://github.com/CheesecakeLabs/.github"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/actions"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/AndroidNotifiCrashLib"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/cheesecake-cli"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/cheesecake-core-android"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/CKDraggableModalController"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/ckl-components-test-api"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/ckl-rest-auth"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/CKLNetworkSwift"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/codingdojo"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/cra-template-ckl-frontend"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/cupcaker-backend-challenge"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/cupcaker-flutter-challenge"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/cupcaker-rn-challenge"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/cupcaker-web-challenge"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/cz-ckl-jira-smart-commit"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/django-apistar-boilerplate"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/django-drf-boilerplate"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/django-geoposition"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/django-polaris-bitgo"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/django-polaris-wyre"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/DMActivityInstagram"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/ecrawler-frontend"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/ecs-deploy-ci"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/eslint-config-cheesecakelabs"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/EZCoreData"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/fetch"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/flutter_weather_bg_null_safety"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/front-end-boilerplate"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/gatsby-boilerplate"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/gatsby-plugin-intl"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/gjira"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/heroku-buildback-dd-tracer-php"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/heroku-buildpack-python"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/heroku-geo-buildpack"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/homebrew-cheesecake-cli"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/iOSNotifiCrashLib"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/JSQMessagesViewController"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/libPusher"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/mao-na-massa-backend"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/maonamassa-turma1"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/maonamassa-web-turma1"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/mapbox-android-sdk-legacy"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/mnm-olhar-horizontal"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/moria-contracts"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/neo4j-node-ogm"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/nodejs-skeleton"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/nodesetup"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/oce"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/PageMenu"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/Panorama"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/PBJVision"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/poketoken-article"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/Profile-Me"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/pythonocc-core"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/pythonocc-utils"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/raspberry-pi-wifi-config"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/react-native-google-analytics-bridge"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/react-next-boilerplate"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/react-redux-boilerplate"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/react-redux-boilerplate-utils"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/react_js_project"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/ReactNativeCklExample"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/researches"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/selenium-serverless-example"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/Sketch-Bootstrap-Grid-Template"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/slackin"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/soroban-dapps"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/soroban-example-dapp"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/soroban-poc"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/sorobanathon-allowance"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/starbridge"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/Stellar-Asset-Sandbox"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/stellar-dashboard"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/stellar-new-docs"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/stellar-plus"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/SwiftSocket"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/TwicketSegmentedControl"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/wagtail-boilerplate"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/web-vanilla-boilerplate"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/ws-backend"
+
+[[repo]]
+url = "https://github.com/CheesecakeLabs/XMPPFramework"
+
+[[repo]]
+url = "https://github.com/fazzatti/SEPAuditTool"
+
+[[repo]]
+url = "https://github.com/fazzatti/stellar-plus-examples"
+
+[[repo]]
+url = "https://github.com/hyperledger/cacti"
+
+[[repo]]
+url = "https://github.com/Julian-dev28/consensus-hackathon-c2defi"
+
+[[repo]]
+url = "https://github.com/mreddychitti/stellar-apps"
+
+[[repo]]
+url = "https://github.com/vandenhaak/whitehydrogen"
+
+[[repo]]
+url = "https://github.com/vandenhaak/whitehydrogendefi"

--- a/data/ecosystems/s/stellar.toml
+++ b/data/ecosystems/s/stellar.toml
@@ -6,6 +6,7 @@ sub_ecosystems = [
   "Aquarius (AQUA token)",
   "AssetDesk",
   "BP Ventures",
+  "Cheesecake Labs",
   "CometDEX",
   "DSTOQ",
   "Edge",


### PR DESCRIPTION
Cheesecake Labs is a very active dev organization in the Stellar ecosystem. This commit adds them as their own sub-ecosystem of Stellar. It seemed like a sub-ecosystem was warranted for two reasons:

1. (Mainly this one) They've developed their own `stellar-plus` SDK which wraps/enhances the SDF-maintained JavaScript SDK. There are several repositories using that as a dependency (as can be seen at the bottom of the [new] `cheesecake-labs.toml` file).
2. There's quite a long list of repos in their GH org.

If there's a better rubric you all use for determining if something is more fit to be in the `sub_ecosystems` vs the `github_organizations`, I'm more than happy to adjust this (and any following) PRs accordingly.

Thanks!

> _Note:_ I'm well aware that we're past the deadline for the midyear update, and I have no expectations that this change would be included/reflected in that midyear data. Just trying to keep things up-to-date moving forward.