### PR TITLE
Add Titus Finance to Aptos ecosystem

### DIFF
--- a/data/ecosystems/a/aptos.toml
+++ b/data/ecosystems/a/aptos.toml
@@ -8125,3 +8125,6 @@ url = "https://github.com/zxf000000/aptos-tools-frontend"
 
 [[repo]]
 url = "https://github.com/Zy-jay/swap"
+
+[[repo]]
+url = "https://github.com/titus-finance/core"


### PR DESCRIPTION
This PR adds Titus Finance (https://github.com/titus-finance/core) to the Aptos ecosystem.