### PR TITLE
Add Titus-finance to Aptos ecosystem

### DIFF
--- a/data/ecosystems/a/aptos.toml
+++ b/data/ecosystems/a/aptos.toml
@@ -76,6 +76,7 @@ github_organizations = [
 # Repositories
 [[repo]]
 url = "https://github.com/04Akaps/Aptos_Move"
+url = "https://github.com/titus-finance/core"
 
 [[repo]]
 url = "https://github.com/0LNetworkCommunity/aptos-core"

--- a/data/ecosystems/t/titus-finance.toml
+++ b/data/ecosystems/t/titus-finance.toml
@@ -1,0 +1,7 @@
+# Ecosystem Level Information
+  title = "Titus-finance"
+  sub_ecosystems = []
+  github_organizations = ["github.com/titus-finance"]
+  
+  [[repo]]
+  url = "https://github.com/titus-finance/core"


### PR DESCRIPTION
This PR adds Titus-finance (https://github.com/titus-finance/core) to the Aptos ecosystem and creates a new ecosystem file.