### PR TITLE
Add Eiger repositories

### DIFF
--- a/data/ecosystems/a/aptos.toml
+++ b/data/ecosystems/a/aptos.toml
@@ -10042,3 +10042,9 @@ url = "https://github.com/zxf000000/aptos-tools-frontend"
 [[repo]]
 url = "https://github.com/Zy-jay/swap"
 missing = true
+
+[[repo]]
+url = "https://github.com/eigerco/move-spec-testing"
+
+[[repo]]
+url = "https://github.com/eigerco/pallet-move"

--- a/data/ecosystems/a/axelar-network.toml
+++ b/data/ecosystems/a/axelar-network.toml
@@ -282,3 +282,6 @@ url = "https://github.com/axelarnetwork/whitepaper"
 
 [[repo]]
 url = "https://github.com/bro-n-bro/cybernode"
+
+[[repo]]
+url = "https://github.com/eigerco/solana-axelar"

--- a/data/ecosystems/c/celestia.toml
+++ b/data/ecosystems/c/celestia.toml
@@ -538,3 +538,27 @@ url = "https://github.com/XF0707/celestia"
 
 [[repo]]
 url = "https://github.com/yu-org/yu"
+
+[[repo]]
+url = "https://github.com/eigerco/beetswap"
+
+[[repo]]
+url = "https://github.com/eigerco/blockstore"
+
+[[repo]]
+url = "https://github.com/eigerco/celestia-tendermint-rs"
+
+[[repo]]
+url = "https://github.com/eigerco/leopard-codec"
+
+[[repo]]
+url = "https://github.com/eigerco/lightray"
+
+[[repo]]
+url = "https://github.com/eigerco/lumina"
+
+[[repo]]
+url = "https://github.com/eigerco/lumina-activity"
+
+[[repo]]
+url = "https://github.com/eigerco/lumina-front"

--- a/data/ecosystems/e/eiger.toml
+++ b/data/ecosystems/e/eiger.toml
@@ -3,8 +3,4 @@ title = "Eiger"
 
 sub_ecosystems = []
 
-github_organizations = []
-
-# Repositories
-[[repo]]
-url = "https://github.com/eigerco/ethereum-canister"
+github_organizations = ["https://github.com/eigerco"]

--- a/data/ecosystems/l/libp2p.toml
+++ b/data/ecosystems/l/libp2p.toml
@@ -811,3 +811,6 @@ url = "https://github.com/libp2p/xtp"
 
 [[repo]]
 url = "https://github.com/libp2p/zeroconf"
+
+[[repo]]
+url = "https://github.com/eigerco/beetswap"

--- a/data/ecosystems/m/move.toml
+++ b/data/ecosystems/m/move.toml
@@ -296,3 +296,21 @@ url = "https://github.com/web3-lab-dao/move-tutorial"
 
 [[repo]]
 url = "https://github.com/Zellic/move-prover-examples"
+
+[[repo]]
+url = "https://github.com/eigerco/pallet-move"
+
+[[repo]]
+url = "https://github.com/eigerco/smove"
+
+[[repo]]
+url = "https://github.com/eigerco/move-stdlib"
+
+[[repo]]
+url = "https://github.com/eigerco/substrate-move"
+
+[[repo]]
+url = "https://github.com/eigerco/substrate-stdlib"
+
+[[repo]]
+url = "https://github.com/eigerco/move-spec-testing"

--- a/data/ecosystems/p/polkadot-network.toml
+++ b/data/ecosystems/p/polkadot-network.toml
@@ -30095,3 +30095,18 @@ tags = ["Chains and Pallets, Gaming"]
 
 [[repo]]
 url = "https://gitlab.com/dinfra/dinfra"
+
+[[repo]]
+url = "https://github.com/eigerco/pallet-move"
+
+[[repo]]
+url = "https://github.com/eigerco/smove"
+
+[[repo]]
+url = "https://github.com/eigerco/move-stdlib"
+
+[[repo]]
+url = "https://github.com/eigerco/substrate-move"
+
+[[repo]]
+url = "https://github.com/eigerco/substrate-stdlib"

--- a/data/ecosystems/s/solana.toml
+++ b/data/ecosystems/s/solana.toml
@@ -128756,3 +128756,6 @@ url = "https://gitlab.com/dysonswap/tachyon-test"
 [[repo]]
 url = "https://gitlab.com/sigrlami/omuon"
 missing = true
+
+[[repo]]
+url = "https://github.com/eigerco/solana-spec"

--- a/data/ecosystems/t/tendermint.toml
+++ b/data/ecosystems/t/tendermint.toml
@@ -2045,3 +2045,6 @@ missing = true
 
 [[repo]]
 url = "https://github.com/zorancuc/kvstore"
+
+[[repo]]
+url = "https://github.com/eigerco/celestia-tendermint-rs"

--- a/data/ecosystems/z/zcash.toml
+++ b/data/ecosystems/z/zcash.toml
@@ -549,3 +549,12 @@ url = "https://github.com/zingolabs/zingolib"
 
 [[repo]]
 url = "https://github.com/Zondax/ledger-zcash"
+
+[[repo]]
+url = "https://github.com/eigerco/uniffi-zcash-lib"
+
+[[repo]]
+url = "https://github.com/eigerco/zsf-fee-estimator"
+
+[[repo]]
+url = "https://github.com/eigerco/zsf-simulator"


### PR DESCRIPTION
1. Fixed eiger.toml by adding the github org link and removing the sole repo, as instructed in the readme the system should pull all repos automatically
`github_organizations = ["https://github.com/eigerco"]`

2. Added relevant Eiger repos to the appropriate ecosystems.