### PR TITLE
Remove fishy solana-py repository

### DIFF
--- a/data/ecosystems/s/solana.toml
+++ b/data/ecosystems/s/solana.toml
@@ -81130,9 +81130,6 @@ url = "https://github.com/michals92/sollama-ios"
 url = "https://github.com/miche1e/escrow-program"
 
 [[repo]]
-url = "https://github.com/michealhly/solana-py"
-
-[[repo]]
 url = "https://github.com/michealkeines/Rust"
 
 [[repo]]


### PR DESCRIPTION
The correct repo is `michaelhly/solana-py`.
The fishy repo is `michealhly/solana-py`.