### PR TITLE
rename tonlabs->everx-labs

### DIFF
--- a/data/ecosystems/e/everscale.toml
+++ b/data/ecosystems/e/everscale.toml
@@ -1729,9 +1729,6 @@ url = "https://github.com/everx-labs/ever-block-json"
 url = "https://github.com/everx-labs/ever-bls-lib"
 
 [[repo]]
-url = "https://github.com/everx-labs/ever-cli"
-
-[[repo]]
 url = "https://github.com/everx-labs/ever-crypto"
 
 [[repo]]
@@ -2078,9 +2075,6 @@ url = "https://github.com/tonsoft-org/alpha.wallet"
 [[repo]]
 url = "https://github.com/unboxedtype/light"
 tags = ["Developer Tools", "Language"]
-
-[[repo]]
-url = "https://github.com/varnav/freeton-node-docker"
 
 [[repo]]
 url = "https://github.com/vp-mazekine/EverCraft"

--- a/data/ecosystems/e/everscale.toml
+++ b/data/ecosystems/e/everscale.toml
@@ -10,7 +10,7 @@ github_organizations = [
   "https://github.com/INTONNATION",
   "https://github.com/radianceteam",
   "https://github.com/RSquad",
-  "https://github.com/tonlabs",
+  "https://github.com/everx-labs",
 ]
 
 # Repositories
@@ -1624,450 +1624,450 @@ url = "https://github.com/SVOIcom/tonswap-SC"
 url = "https://github.com/TonexWallet/tonex-extension"
 
 [[repo]]
-url = "https://github.com/tonlabs/admin-tool"
+url = "https://github.com/everx-labs/admin-tool"
 
 [[repo]]
-url = "https://github.com/tonlabs/arangochair"
+url = "https://github.com/everx-labs/arangochair"
 
 [[repo]]
-url = "https://github.com/tonlabs/bip39-rs"
+url = "https://github.com/everx-labs/bip39-rs"
 
 [[repo]]
-url = "https://github.com/tonlabs/Burrow"
+url = "https://github.com/everx-labs/Burrow"
 
 [[repo]]
-url = "https://github.com/tonlabs/che"
+url = "https://github.com/everx-labs/che"
 
 [[repo]]
-url = "https://github.com/tonlabs/chess-match-making"
+url = "https://github.com/everx-labs/chess-match-making"
 
 [[repo]]
-url = "https://github.com/tonlabs/cloud-t-rex"
+url = "https://github.com/everx-labs/cloud-t-rex"
 missing = true
 
 [[repo]]
-url = "https://github.com/tonlabs/cmake_modules"
+url = "https://github.com/everx-labs/cmake_modules"
 
 [[repo]]
-url = "https://github.com/tonlabs/common"
+url = "https://github.com/everx-labs/common"
 
 [[repo]]
-url = "https://github.com/tonlabs/contests-v2"
+url = "https://github.com/everx-labs/contests-v2"
 
 [[repo]]
-url = "https://github.com/tonlabs/crypto3-algebra"
+url = "https://github.com/everx-labs/crypto3-algebra"
 
 [[repo]]
-url = "https://github.com/tonlabs/crypto3-algebra-marshalling"
+url = "https://github.com/everx-labs/crypto3-algebra-marshalling"
 
 [[repo]]
-url = "https://github.com/tonlabs/crypto3-block"
+url = "https://github.com/everx-labs/crypto3-block"
 
 [[repo]]
-url = "https://github.com/tonlabs/crypto3-hash"
+url = "https://github.com/everx-labs/crypto3-hash"
 
 [[repo]]
-url = "https://github.com/tonlabs/crypto3-math"
+url = "https://github.com/everx-labs/crypto3-math"
 
 [[repo]]
-url = "https://github.com/tonlabs/crypto3-multiprecision"
+url = "https://github.com/everx-labs/crypto3-multiprecision"
 
 [[repo]]
-url = "https://github.com/tonlabs/crypto3-multiprecision-marshalling"
+url = "https://github.com/everx-labs/crypto3-multiprecision-marshalling"
 
 [[repo]]
-url = "https://github.com/tonlabs/crypto3-zk"
+url = "https://github.com/everx-labs/crypto3-zk"
 
 [[repo]]
-url = "https://github.com/tonlabs/crypto3-zk-marshalling"
+url = "https://github.com/everx-labs/crypto3-zk-marshalling"
 
 [[repo]]
-url = "https://github.com/tonlabs/dapp-data-transfer"
+url = "https://github.com/everx-labs/dapp-data-transfer"
 missing = true
 
 [[repo]]
-url = "https://github.com/tonlabs/dapp-remp-subscriptions"
+url = "https://github.com/everx-labs/dapp-remp-subscriptions"
 
 [[repo]]
-url = "https://github.com/tonlabs/dapp-services"
+url = "https://github.com/everx-labs/dapp-services"
 missing = true
 
 [[repo]]
-url = "https://github.com/tonlabs/dapp-services-ranger"
+url = "https://github.com/everx-labs/dapp-services-ranger"
 
 [[repo]]
-url = "https://github.com/tonlabs/debot-engine"
+url = "https://github.com/everx-labs/debot-engine"
 
 [[repo]]
-url = "https://github.com/tonlabs/DeBot-IS-consortium"
+url = "https://github.com/everx-labs/DeBot-IS-consortium"
 
 [[repo]]
-url = "https://github.com/tonlabs/debots"
+url = "https://github.com/everx-labs/debots"
 
 [[repo]]
-url = "https://github.com/tonlabs/electron-forge-maker-appimage"
+url = "https://github.com/everx-labs/electron-forge-maker-appimage"
 
 [[repo]]
-url = "https://github.com/tonlabs/ever-abi"
+url = "https://github.com/everx-labs/ever-abi"
 
 [[repo]]
-url = "https://github.com/tonlabs/ever-adnl"
+url = "https://github.com/everx-labs/ever-adnl"
 
 [[repo]]
-url = "https://github.com/tonlabs/ever-appkit-js"
+url = "https://github.com/everx-labs/ever-appkit-js"
 
 [[repo]]
-url = "https://github.com/tonlabs/ever-assembler"
+url = "https://github.com/everx-labs/ever-assembler"
 
 [[repo]]
-url = "https://github.com/tonlabs/ever-block"
+url = "https://github.com/everx-labs/ever-block"
 
 [[repo]]
-url = "https://github.com/tonlabs/ever-block-json"
+url = "https://github.com/everx-labs/ever-block-json"
 
 [[repo]]
-url = "https://github.com/tonlabs/ever-bls-lib"
+url = "https://github.com/everx-labs/ever-bls-lib"
 
 [[repo]]
-url = "https://github.com/tonlabs/ever-cli"
+url = "https://github.com/everx-labs/ever-cli"
 
 [[repo]]
-url = "https://github.com/tonlabs/ever-crypto"
+url = "https://github.com/everx-labs/ever-crypto"
 
 [[repo]]
-url = "https://github.com/tonlabs/ever-dht"
+url = "https://github.com/everx-labs/ever-dht"
 
 [[repo]]
-url = "https://github.com/tonlabs/ever-executor"
+url = "https://github.com/everx-labs/ever-executor"
 
 [[repo]]
-url = "https://github.com/tonlabs/ever-labs-bls-lib"
+url = "https://github.com/everx-labs/ever-labs-bls-lib"
 
 [[repo]]
-url = "https://github.com/tonlabs/ever-labs-crypto"
+url = "https://github.com/everx-labs/ever-labs-crypto"
 
 [[repo]]
-url = "https://github.com/tonlabs/ever-node"
+url = "https://github.com/everx-labs/ever-node"
 
 [[repo]]
-url = "https://github.com/tonlabs/ever-node-rpc"
+url = "https://github.com/everx-labs/ever-node-rpc"
 missing = true
 
 [[repo]]
-url = "https://github.com/tonlabs/ever-node-tools"
+url = "https://github.com/everx-labs/ever-node-tools"
 
 [[repo]]
-url = "https://github.com/tonlabs/ever-overlay"
+url = "https://github.com/everx-labs/ever-overlay"
 
 [[repo]]
-url = "https://github.com/tonlabs/ever-platform-docs"
+url = "https://github.com/everx-labs/ever-platform-docs"
 
 [[repo]]
-url = "https://github.com/tonlabs/ever-playground"
+url = "https://github.com/everx-labs/ever-playground"
 
 [[repo]]
-url = "https://github.com/tonlabs/ever-rldp"
+url = "https://github.com/everx-labs/ever-rldp"
 
 [[repo]]
-url = "https://github.com/tonlabs/ever-sdk"
+url = "https://github.com/everx-labs/ever-sdk"
 
 [[repo]]
-url = "https://github.com/tonlabs/ever-sdk-js"
+url = "https://github.com/everx-labs/ever-sdk-js"
 
 [[repo]]
-url = "https://github.com/tonlabs/ever-struct"
+url = "https://github.com/everx-labs/ever-struct"
 
 [[repo]]
-url = "https://github.com/tonlabs/ever-tl"
+url = "https://github.com/everx-labs/ever-tl"
 
 [[repo]]
-url = "https://github.com/tonlabs/ever-types"
+url = "https://github.com/everx-labs/ever-types"
 
 [[repo]]
-url = "https://github.com/tonlabs/ever-vm"
+url = "https://github.com/everx-labs/ever-vm"
 
 [[repo]]
-url = "https://github.com/tonlabs/everdev"
+url = "https://github.com/everx-labs/everdev"
 
 [[repo]]
-url = "https://github.com/tonlabs/everdev-vscode"
+url = "https://github.com/everx-labs/everdev-vscode"
 
 [[repo]]
-url = "https://github.com/tonlabs/evernode-ds"
+url = "https://github.com/everx-labs/evernode-ds"
 
 [[repo]]
-url = "https://github.com/tonlabs/Evernode-NQ"
+url = "https://github.com/everx-labs/Evernode-NQ"
 
 [[repo]]
-url = "https://github.com/tonlabs/evernode-se"
+url = "https://github.com/everx-labs/evernode-se"
 
 [[repo]]
-url = "https://github.com/tonlabs/everos-cli"
+url = "https://github.com/everx-labs/ever-cli"
 
 [[repo]]
-url = "https://github.com/tonlabs/eversdk-ton"
+url = "https://github.com/everx-labs/eversdk-ton"
 
 [[repo]]
-url = "https://github.com/tonlabs/everx-node"
+url = "https://github.com/everx-labs/everx-node"
 missing = true
 
 [[repo]]
-url = "https://github.com/tonlabs/firebase-ios-sdk"
+url = "https://github.com/everx-labs/firebase-ios-sdk"
 
 [[repo]]
-url = "https://github.com/tonlabs/flex"
+url = "https://github.com/everx-labs/flex"
 
 [[repo]]
-url = "https://github.com/tonlabs/flex-sdk-js"
+url = "https://github.com/everx-labs/flex-sdk-js"
 
 [[repo]]
-url = "https://github.com/tonlabs/Foundation-site"
+url = "https://github.com/everx-labs/Foundation-site"
 
 [[repo]]
-url = "https://github.com/tonlabs/github-tag-action"
+url = "https://github.com/everx-labs/github-tag-action"
 
 [[repo]]
-url = "https://github.com/tonlabs/gosh"
+url = "https://github.com/everx-labs/gosh"
 missing = true
 
 [[repo]]
-url = "https://github.com/tonlabs/gosh-gitbook"
+url = "https://github.com/everx-labs/gosh-gitbook"
 
 [[repo]]
-url = "https://github.com/tonlabs/graphql-playground"
+url = "https://github.com/everx-labs/graphql-playground"
 
 [[repo]]
-url = "https://github.com/tonlabs/highlights"
+url = "https://github.com/everx-labs/highlights"
 
 [[repo]]
-url = "https://github.com/tonlabs/ipcnv"
+url = "https://github.com/everx-labs/ipcnv"
 
 [[repo]]
-url = "https://github.com/tonlabs/kafka-connect-arangodb"
+url = "https://github.com/everx-labs/kafka-connect-arangodb"
 
 [[repo]]
-url = "https://github.com/tonlabs/lockfree"
+url = "https://github.com/everx-labs/lockfree"
 
 [[repo]]
-url = "https://github.com/tonlabs/main.ton.dev"
+url = "https://github.com/everx-labs/main.ton.dev"
 
 [[repo]]
-url = "https://github.com/tonlabs/marshalling"
+url = "https://github.com/everx-labs/marshalling"
 
 [[repo]]
-url = "https://github.com/tonlabs/net.ton.dev"
+url = "https://github.com/everx-labs/net.ton.dev"
 
 [[repo]]
-url = "https://github.com/tonlabs/react-native-awesome-alerts"
+url = "https://github.com/everx-labs/react-native-awesome-alerts"
 
 [[repo]]
-url = "https://github.com/tonlabs/react-native-blur"
+url = "https://github.com/everx-labs/react-native-blur"
 
 [[repo]]
-url = "https://github.com/tonlabs/react-native-country-picker-modal"
+url = "https://github.com/everx-labs/react-native-country-picker-modal"
 
 [[repo]]
-url = "https://github.com/tonlabs/react-native-indicators"
+url = "https://github.com/everx-labs/react-native-indicators"
 
 [[repo]]
-url = "https://github.com/tonlabs/react-native-keychain"
+url = "https://github.com/everx-labs/react-native-keychain"
 
 [[repo]]
-url = "https://github.com/tonlabs/react-native-modern-datepicker"
+url = "https://github.com/everx-labs/react-native-modern-datepicker"
 
 [[repo]]
-url = "https://github.com/tonlabs/react-native-qrcode-scanner"
+url = "https://github.com/everx-labs/react-native-qrcode-scanner"
 
 [[repo]]
-url = "https://github.com/tonlabs/react-native-scrollable-navigation-bar"
+url = "https://github.com/everx-labs/react-native-scrollable-navigation-bar"
 
 [[repo]]
-url = "https://github.com/tonlabs/react-native-simple-popover"
+url = "https://github.com/everx-labs/react-native-simple-popover"
 
 [[repo]]
-url = "https://github.com/tonlabs/react-native-ui-lib"
+url = "https://github.com/everx-labs/react-native-ui-lib"
 
 [[repo]]
-url = "https://github.com/tonlabs/react-native-video"
+url = "https://github.com/everx-labs/react-native-video"
 
 [[repo]]
-url = "https://github.com/tonlabs/react-navigation-surf"
+url = "https://github.com/everx-labs/react-navigation-surf"
 
 [[repo]]
-url = "https://github.com/tonlabs/rust-crypto"
+url = "https://github.com/everx-labs/rust-crypto"
 
 [[repo]]
-url = "https://github.com/tonlabs/rust-statsd"
+url = "https://github.com/everx-labs/rust-statsd"
 
 [[repo]]
-url = "https://github.com/tonlabs/rustnet.ton.dev"
+url = "https://github.com/everx-labs/rustnet.ton.dev"
 
 [[repo]]
-url = "https://github.com/tonlabs/samples"
+url = "https://github.com/everx-labs/samples"
 
 [[repo]]
-url = "https://github.com/tonlabs/sdk-samples"
+url = "https://github.com/everx-labs/sdk-samples"
 
 [[repo]]
-url = "https://github.com/tonlabs/sodalite"
+url = "https://github.com/everx-labs/sodalite"
 
 [[repo]]
-url = "https://github.com/tonlabs/stdlib.sol"
+url = "https://github.com/everx-labs/stdlib.sol"
 
 [[repo]]
-url = "https://github.com/tonlabs/stTONs"
+url = "https://github.com/everx-labs/stTONs"
 
 [[repo]]
-url = "https://github.com/tonlabs/subscriptions-transport-ws"
+url = "https://github.com/everx-labs/subscriptions-transport-ws"
 
 [[repo]]
-url = "https://github.com/tonlabs/surf-external"
+url = "https://github.com/everx-labs/surf-external"
 
 [[repo]]
-url = "https://github.com/tonlabs/Surf-Releases"
+url = "https://github.com/everx-labs/Surf-Releases"
 
 [[repo]]
-url = "https://github.com/tonlabs/TestSuite4"
+url = "https://github.com/everx-labs/TestSuite4"
 
 [[repo]]
-url = "https://github.com/tonlabs/TIP"
+url = "https://github.com/everx-labs/TIP"
 
 [[repo]]
-url = "https://github.com/tonlabs/tl-parser"
+url = "https://github.com/everx-labs/tl-parser"
 
 [[repo]]
-url = "https://github.com/tonlabs/ton-1"
+url = "https://github.com/everx-labs/ton-1"
 
 [[repo]]
-url = "https://github.com/tonlabs/ton-client-node-js"
+url = "https://github.com/everx-labs/ton-client-node-js"
 
 [[repo]]
-url = "https://github.com/tonlabs/ton-client-react-native-js"
+url = "https://github.com/everx-labs/ton-client-react-native-js"
 
 [[repo]]
-url = "https://github.com/tonlabs/ton-client-rs"
+url = "https://github.com/everx-labs/ton-client-rs"
 
 [[repo]]
-url = "https://github.com/tonlabs/ton-client-web-js"
+url = "https://github.com/everx-labs/ton-client-web-js"
 
 [[repo]]
-url = "https://github.com/tonlabs/TON-Compiler"
+url = "https://github.com/everx-labs/TON-Compiler"
 
 [[repo]]
-url = "https://github.com/tonlabs/ton-dev-cli"
+url = "https://github.com/everx-labs/ton-dev-cli"
 
 [[repo]]
-url = "https://github.com/tonlabs/ton-kafka"
+url = "https://github.com/everx-labs/ton-kafka"
 missing = true
 
 [[repo]]
-url = "https://github.com/tonlabs/ton-labs-abi"
+url = "https://github.com/everx-labs/ton-labs-abi"
 
 [[repo]]
-url = "https://github.com/tonlabs/ton-labs-adnl"
+url = "https://github.com/everx-labs/ton-labs-adnl"
 
 [[repo]]
-url = "https://github.com/tonlabs/ton-labs-assembler"
+url = "https://github.com/everx-labs/ton-labs-assembler"
 
 [[repo]]
-url = "https://github.com/tonlabs/ton-labs-block"
+url = "https://github.com/everx-labs/ton-labs-block"
 
 [[repo]]
-url = "https://github.com/tonlabs/ton-labs-block-json"
+url = "https://github.com/everx-labs/ton-labs-block-json"
 
 [[repo]]
-url = "https://github.com/tonlabs/ton-labs-contracts"
+url = "https://github.com/everx-labs/ton-labs-contracts"
 
 [[repo]]
-url = "https://github.com/tonlabs/ton-labs-dht"
+url = "https://github.com/everx-labs/ton-labs-dht"
 
 [[repo]]
-url = "https://github.com/tonlabs/ton-labs-executor"
+url = "https://github.com/everx-labs/ton-labs-executor"
 
 [[repo]]
-url = "https://github.com/tonlabs/ton-labs-node"
+url = "https://github.com/everx-labs/ton-labs-node"
 
 [[repo]]
-url = "https://github.com/tonlabs/ton-labs-node-storage"
+url = "https://github.com/everx-labs/ton-labs-node-storage"
 
 [[repo]]
-url = "https://github.com/tonlabs/ton-labs-node-tools"
+url = "https://github.com/everx-labs/ton-labs-node-tools"
 
 [[repo]]
-url = "https://github.com/tonlabs/ton-labs-overlay"
+url = "https://github.com/everx-labs/ton-labs-overlay"
 
 [[repo]]
-url = "https://github.com/tonlabs/ton-labs-rldp"
+url = "https://github.com/everx-labs/ton-labs-rldp"
 
 [[repo]]
-url = "https://github.com/tonlabs/ton-labs-tl"
+url = "https://github.com/everx-labs/ton-labs-tl"
 
 [[repo]]
-url = "https://github.com/tonlabs/ton-labs-types"
+url = "https://github.com/everx-labs/ton-labs-types"
 
 [[repo]]
-url = "https://github.com/tonlabs/ton-labs-vm"
+url = "https://github.com/everx-labs/ton-labs-vm"
 
 [[repo]]
-url = "https://github.com/tonlabs/ton-monorepo"
+url = "https://github.com/everx-labs/ton-monorepo"
 
 [[repo]]
-url = "https://github.com/tonlabs/ton-nfc-client"
+url = "https://github.com/everx-labs/ton-nfc-client"
 
 [[repo]]
-url = "https://github.com/tonlabs/ton-q-server"
+url = "https://github.com/everx-labs/ton-q-server"
 
 [[repo]]
-url = "https://github.com/tonlabs/TON-Solidity-Compiler"
+url = "https://github.com/everx-labs/TON-Solidity-Compiler"
 
 [[repo]]
-url = "https://github.com/tonlabs/TON-Surf-Localization"
+url = "https://github.com/everx-labs/TON-Surf-Localization"
 
 [[repo]]
-url = "https://github.com/tonlabs/tondev"
+url = "https://github.com/everx-labs/tondev"
 
 [[repo]]
-url = "https://github.com/tonlabs/tonix"
+url = "https://github.com/everx-labs/tonix"
 
 [[repo]]
-url = "https://github.com/tonlabs/TonNfcClientAndroid"
+url = "https://github.com/everx-labs/TonNfcClientAndroid"
 
 [[repo]]
-url = "https://github.com/tonlabs/TonNfcClientSwift"
+url = "https://github.com/everx-labs/TonNfcClientSwift"
 
 [[repo]]
-url = "https://github.com/tonlabs/tonos-cli"
+url = "https://github.com/everx-labs/tonos-cli"
 
 [[repo]]
-url = "https://github.com/tonlabs/tor-service"
+url = "https://github.com/everx-labs/tor-service"
 
 [[repo]]
-url = "https://github.com/tonlabs/True-NFT"
+url = "https://github.com/everx-labs/True-NFT"
 
 [[repo]]
-url = "https://github.com/tonlabs/TVM-Compiler"
+url = "https://github.com/everx-labs/TVM-Compiler"
 
 [[repo]]
-url = "https://github.com/tonlabs/TVM-linker"
+url = "https://github.com/everx-labs/TVM-linker"
 
 [[repo]]
-url = "https://github.com/tonlabs/TVM-Solidity-Compiler"
+url = "https://github.com/everx-labs/TVM-Solidity-Compiler"
 
 [[repo]]
-url = "https://github.com/tonlabs/UIKit"
+url = "https://github.com/everx-labs/UIKit"
 
 [[repo]]
-url = "https://github.com/tonlabs/wallet-sdk-js"
+url = "https://github.com/everx-labs/wallet-sdk-js"
 
 [[repo]]
-url = "https://github.com/tonlabs/worldchess"
+url = "https://github.com/everx-labs/worldchess"
 missing = true
 
 [[repo]]
-url = "https://github.com/tonlabs/x25519-dalek"
+url = "https://github.com/everx-labs/x25519-dalek"
 
 [[repo]]
-url = "https://github.com/tonlabs/zstd-rs"
+url = "https://github.com/everx-labs/zstd-rs"
 
 [[repo]]
 url = "https://github.com/tonsoft-org/alpha.browser.wallet"


### PR DESCRIPTION
tonlabs was rebranding to everX
source: https://github.com/tonlabs contains link to https://github.com/everx-labs