### PR TITLE
Update algorand.toml: Remove repo spamming commits, which fakes developer activity

### DIFF
--- a/data/ecosystems/a/algorand.toml
+++ b/data/ecosystems/a/algorand.toml
@@ -1848,9 +1848,6 @@ url = "https://github.com/AlgoRealm/algorealm-cli"
 url = "https://github.com/AlgoStation/AlgoPass"
 
 [[repo]]
-url = "https://github.com/algotables/algotables.github.io"
-
-[[repo]]
 url = "https://github.com/AlgoTheOwl/among-owls"
 
 [[repo]]


### PR DESCRIPTION
Removed 1 repo spamming commits, which fakes developer activity.

- `algotables/algotables.github.io`
  - Spams one or more commits a minute with a Google Script. Usually the commits are [empty](https://github.com/algotables/algotables.github.io/commit/ff1e9e9f118c47811ab007f09d0102f88a96af9b).
  - Doesn't interact with the blockchain, or provide documentation either.
  - Doesn't provide developer tools as the README suggests.

![image](https://github.com/user-attachments/assets/066ce190-d1ff-4d2a-adbd-e29aca080e89)

This skews rankings on websites using the `crypto-ecosystems` dataset.

### Artemis.xyz

![image](https://github.com/user-attachments/assets/ee0fb689-ffcf-4c0d-98c6-42ab2b94d0dd)

### Cryptometheus

![image](https://github.com/user-attachments/assets/4b4721f8-233e-42e7-b14c-76532ff1f0f1)

