### PR TITLE
Add Structs to the Crypto Ecosystems repo

### DIFF
--- a/data/ecosystems/c/cosmos-network.toml
+++ b/data/ecosystems/c/cosmos-network.toml
@@ -140,6 +140,7 @@ sub_ecosystems = [
   "Stargaze",
   "Starname",
   "Stride Labs",
+  "Structs",
   "Teritori",
   "Terra",
   "Terra Classic",
@@ -15504,6 +15505,9 @@ url = "https://github.com/platocrypto/cosmwasm101"
 [[repo]]
 url = "https://github.com/playerfury/fury"
 missing = true
+
+[[repo]]
+url = "https://github.com/playstructs/structsd"
 
 [[repo]]
 url = "https://github.com/Plex-Engineer/ethermint"

--- a/data/ecosystems/s/structs.toml
+++ b/data/ecosystems/s/structs.toml
@@ -7,7 +7,7 @@ github_organizations = ["https://github.com/playstructs"]
 
 # Repositories
 [[repo]]
-url = "https://github.com/playstructs/structsd"
+url = "https://github.com/playstructs/structs-ui"
 
 [[repo]]
-url = "https://github.com/playstructs/structs-ui"
+url = "https://github.com/playstructs/structsd"

--- a/data/ecosystems/s/structs.toml
+++ b/data/ecosystems/s/structs.toml
@@ -1,0 +1,13 @@
+# Ecosystem Level Information
+title = "Structs"
+
+sub_ecosystems = []
+
+github_organizations = ["https://github.com/playstructs"]
+
+# Repositories
+[[repo]]
+url = "https://github.com/playstructs/structsd"
+
+[[repo]]
+url = "https://github.com/playstructs/structs-ui"


### PR DESCRIPTION
This PR adds a Structs entry as it's own ecosystem, as well as adds it as a sub-ecosystem to the Cosmos Network. 

### Structs
In the distant future, the species of the galaxy are embroiled in a race for Alpha Matter—the rare and dangerous substance that fuels galactic civilization. Players take command of Structs, a race of sentient machines, to conquer worlds, forge alliances, defeat enemies and expand their influence.

[Structs](https://playstructs.com) is a space-based strategy game designed around community play. Players and Guilds compete to mine Alpha Matter ($ALPHA), raid enemies, and defend their own resources in strategic PVP battles.

Alpha Matter fuels player growth and the infrastructure of the game itself, will be tradable for in-game assets or influence, and grants players a stake in the governance of the game.