### PR TITLE
Update aptos.toml

### DIFF
--- a/data/ecosystems/a/aptos.toml
+++ b/data/ecosystems/a/aptos.toml
@@ -20,6 +20,7 @@ sub_ecosystems = [
   "BlockEden.xyz",
   "BlockPi Network",
   "Bware Labs",
+  "catylst-3.0",
   "Cellana Finance",
   "Chainbase",
   "ComingChat",
@@ -9233,6 +9234,9 @@ url = "https://github.com/vampire-ab/overmind"
 
 [[repo]]
 url = "https://github.com/vanishcode/okwallet-aptos-wallet-adapter"
+
+[[repo]]
+url = "https://github.com/VanshKapoor07/catylst-3.0"
 
 [[repo]]
 url = "https://github.com/VarunVerma7/Aptos-Contract-Dev-Flow"


### PR DESCRIPTION
added catylst-3.0 under sub_ecosystem and github link under repo in aptos.toml file for project catylst-3.0 (Dappathon)