### PR TITLE
add haiku to dojo ecosystem

### DIFF
--- a/data/ecosystems/d/dojo-engine.toml
+++ b/data/ecosystems/d/dojo-engine.toml
@@ -343,6 +343,9 @@ url = "https://github.com/Starknopoly/contracts"
 url = "https://github.com/taleweaver-ai/taleweaver-v2-gamejam"
 
 [[repo]]
+url = "https://github.com/tensai-labs/haiku"
+
+[[repo]]
 url = "https://github.com/themetacat/PixeLAW2048"
 
 [[repo]]
@@ -362,6 +365,3 @@ url = "https://github.com/z-korp/zknight-contracts"
 
 [[repo]]
 url = "https://github.com/ZackAmes/capsools"
-
-[[repo]]
-url = "https://github.com/tensai-labs/haiku"

--- a/data/ecosystems/d/dojo-engine.toml
+++ b/data/ecosystems/d/dojo-engine.toml
@@ -362,3 +362,6 @@ url = "https://github.com/z-korp/zknight-contracts"
 
 [[repo]]
 url = "https://github.com/ZackAmes/capsools"
+
+[[repo]]
+url = "https://github.com/tensai-labs/haiku"


### PR DESCRIPTION
Added the Haiku repo to the dojo ecosystem.

Haiku is a tool to easily add AI generated content to games developed using the dojo engine.

https://github.com/tensai-labs/haiku

