### PR TITLE
Adds Tolam Earth

### DIFF
--- a/data/ecosystems/h/hedera.toml
+++ b/data/ecosystems/h/hedera.toml
@@ -25,6 +25,7 @@ sub_ecosystems = [
   "PieFi Platform",
   "SaucerSwap Labs",
   "Stader Labs",
+  "Tolam Earth",
   "Trust Enterprises",
   "Tuum Tech",
   "TxMQ, Inc",
@@ -42,6 +43,7 @@ github_organizations = [
   "https://github.com/renderhive-project",
   "https://github.com/stader-labs",
   "https://github.com/the-creators-galaxy",
+  "https://github.com/Tolam-Earth"
 ]
 
 # Repositories


### PR DESCRIPTION
Adds Tolam Earth's GitHub organization account to the file. Also adds Tolam Earth as a sub-ecosystem of the Hedera ecosystem.