### PR TITLE
add "alpine-sshd" repo in RunOnFlux add a Customize wasp Add the Door for Pi  Submit IBM-Blockchain submit the SavjeeCoin

### DIFF
--- a/data/ecosystems/d/door.toml
+++ b/data/ecosystems/d/door.toml
@@ -1,0 +1,10 @@
+# Ecosystem Level Information
+title = "door"
+
+sub_ecosystems = []
+
+github_organizations = ["https://github.com/pi-apps/door"]
+
+# Repositories
+[[repo]]
+url = "https://github.com/pi-apps/door"

--- a/data/ecosystems/f/flux-run-on-flux.toml
+++ b/data/ecosystems/f/flux-run-on-flux.toml
@@ -16,6 +16,9 @@ url = "https://github.com/RunOnFlux/account-abstraction"
 url = "https://github.com/RunOnFlux/alephium-standalone"
 
 [[repo]]
+url = "https://github.com/RunOnFlux/alpine-sshd"
+
+[[repo]]
 url = "https://github.com/RunOnFlux/appsmonitor"
 missing = true
 

--- a/data/ecosystems/i/ibm-blockchain.toml
+++ b/data/ecosystems/i/ibm-blockchain.toml
@@ -1,0 +1,9 @@
+# Ecosystem Level Information
+title = "IBM-Blockchain"
+
+sub_ecosystems = []
+
+github_organizations = ["https://github.com/IBM-Blockchain-Archive"]
+
+# Repositories
+

--- a/data/ecosystems/i/iota.toml
+++ b/data/ecosystems/i/iota.toml
@@ -2779,7 +2779,11 @@ url = "https://github.com/zachalam/frost"
 url = "https://github.com/ZebraDevs/Zebra-Iota-Edge-SDK"
 
 [[repo]]
+url = "https://github.com/zhuweiDark/wasp"
+
+[[repo]]
 url = "https://github.com/zignartech/iotadd-pwo"
 
 [[repo]]
 url = "https://github.com/zignartech/iotadd-streams-sb"
+

--- a/data/ecosystems/r/rippled.toml
+++ b/data/ecosystems/r/rippled.toml
@@ -1,0 +1,21 @@
+# Ecosystem Level Information
+title = "rippled"
+
+sub_ecosystems = []
+
+github_organizations = ["https://github.com/XRPLF"]
+
+# Repositories
+[[repo]]
+url = "https://github.com/XRPLF/clio"
+missing = true
+
+[[repo]]
+url = "https://github.com/XRPLF/rippled"
+missing = true
+
+[[repo]]
+url = "https://github.com/XRPLF/XRPL-Standards"
+missing = true
+
+

--- a/data/ecosystems/r/rippled.toml
+++ b/data/ecosystems/r/rippled.toml
@@ -8,14 +8,14 @@ github_organizations = ["https://github.com/XRPLF"]
 # Repositories
 [[repo]]
 url = "https://github.com/XRPLF/clio"
-missing = true
 
 [[repo]]
 url = "https://github.com/XRPLF/rippled"
-missing = true
+#missing = true
 
 [[repo]]
 url = "https://github.com/XRPLF/XRPL-Standards"
-missing = true
+
+#missing = true
 
 

--- a/data/ecosystems/s/savjeecoin.toml
+++ b/data/ecosystems/s/savjeecoin.toml
@@ -1,0 +1,11 @@
+# Ecosystem Level Information
+title = "SavjeeCoin"
+
+sub_ecosystems = []
+
+github_organizations = ['https://github.com/Savjee','https://github.com/zhuweiDark/SavjeeCoin']
+
+
+# Repositories
+[[repo]]
+url = "https://github.com/Savjee/SavjeeCoin"


### PR DESCRIPTION
add "alpine-sshd" repo in RunOnFlux

Run On Flux
Flux, Your Gateway to a Decentralized World
The simplest/smallest SSH Server
This is a very simple alpine based SSHD server, listening on port 22. It has no fancy stuff. Just SSHD service running in foreground. It allows only key based access, and the user is root. Useful as a jump host inside kubernetes clusters, to further connect to your other secure services behind firewall, etc. You can use it for port forwarding, ssh-agent forwarding, etc.