### PR TITLE
fix: improve directory creation error handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -458,18 +458,19 @@ fn write_ecosystem_to_toml(repo_root: &Path, eco: &Ecosystem) -> Result<()> {
     }
 
     if let Some(parent) = toml_file_path.parent() {
-        std::fs::create_dir_all(parent).map_err(|_| CEError::DirectoryCreationError {
-            path: parent.display().to_string(),
-        })?;
+        std::fs::create_dir_all(parent)
+            .map_err(|_| CEError::DirectoryCreationError {
+                path: parent.display().to_string(),
+            })?;
     }
-    
-    let mut file = OpenOptions::new()
+
+    OpenOptions::new()
         .read(true)
         .write(true)
         .create(true)
         .truncate(true)
-        .open(toml_file_path)?;
-    file.write_all(output.as_bytes())?;
+        .open(toml_file_path)?
+        .write_all(output.as_bytes())?;
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,9 +157,7 @@ enum CEError {
         toml_error: toml::de::Error,
     },
     #[error("Failed to create directory for ecosystem file: {path:?}")]
-    DirectoryCreationError {
-        path: String,
-    },
+    DirectoryCreationError { path: String },
 }
 
 type EcosystemMap = HashMap<String, Ecosystem>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -458,19 +458,18 @@ fn write_ecosystem_to_toml(repo_root: &Path, eco: &Ecosystem) -> Result<()> {
     }
 
     if let Some(parent) = toml_file_path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|_| CEError::DirectoryCreationError {
-                path: parent.display().to_string(),
-            })?;
+        std::fs::create_dir_all(parent).map_err(|_| CEError::DirectoryCreationError {
+            path: parent.display().to_string(),
+        })?;
     }
 
-    OpenOptions::new()
+    let mut file = OpenOptions::new()
         .read(true)
         .write(true)
         .create(true)
         .truncate(true)
-        .open(toml_file_path)?
-        .write_all(output.as_bytes())?;
+        .open(toml_file_path)?;
+    file.write_all(output.as_bytes())?;
     Ok(())
 }
 


### PR DESCRIPTION
- Add DirectoryCreationError variant to CEError enum
- Replace unwrap() with safe directory creation error handling
- Propagate directory creation errors properly through Result