### PR TITLE
Submit the Duino-Coin support

### DIFF
--- a/data/ecosystems/d/duinocoin.toml
+++ b/data/ecosystems/d/duinocoin.toml
@@ -1,0 +1,16 @@
+# Ecosystem Level Information
+title = "Duino-Coin"
+
+sub_ecosystems = []
+
+github_organizations = []
+
+# Repositories
+
+[[repo]]
+url = "https://github.com/Bilaboz/duino-coin-pools"
+
+
+[[repo]]
+url = "https://github.com/revoxhere/duino-coin"
+


### PR DESCRIPTION
… and decentralized ways of storing funds. Duino-Coins can be converted to wDUCO, bscDUCO or others which are the same Duino-Coins but "wrapped" (stored) on other networks as tokens. An example tutorial on using wDUCO is available in the wDUCO wiki. Coins can be wrapped directly from your web Wallet - click the Wrap Coins button to start.
Simple, eco-friendly, centralized coin that can be mined with Arduinos, ESP boards, Raspberry Pis, computers, and many more (including Wi-Fi routers, smart TVs, smartphones, smartwatches, SBCs and other MCUs).