### PR TITLE
feat: zksync updates from updraft

### DIFF
--- a/data/ecosystems/z/zksync.toml
+++ b/data/ecosystems/z/zksync.toml
@@ -116,6 +116,12 @@ url = "https://github.com/0xRake/web"
 url = "https://github.com/0xsergen/pangolin-zksync-exchange-contracts"
 
 [[repo]]
+url = "https://github.com/0xsl0th/foundry-devops"
+
+[[repo]]
+url = "https://github.com/0xsl0th/minimal-account-abstraction"
+
+[[repo]]
 url = "https://github.com/0xStrobe/defillama-server"
 
 [[repo]]
@@ -123,6 +129,9 @@ url = "https://github.com/0xStruct/zksync-oclif"
 
 [[repo]]
 url = "https://github.com/0xtito/social-recovery"
+
+[[repo]]
+url = "https://github.com/0xtrade789/fund-me-0xtrade"
 
 [[repo]]
 url = "https://github.com/0xuqian/testequ"
@@ -174,6 +183,9 @@ url = "https://github.com/4000D/hardhat-deploy-zksync-test"
 url = "https://github.com/4NNNN/AtlasIde"
 
 [[repo]]
+url = "https://github.com/4rdii/Securtiy-Reviews"
+
+[[repo]]
 url = "https://github.com/a-b-d-u-l-s-a-m-e-e-r/Crowd-Funder"
 
 [[repo]]
@@ -201,6 +213,9 @@ missing = true
 
 [[repo]]
 url = "https://github.com/adigupta02/Crowdfunding-Blockchain-Backend"
+
+[[repo]]
+url = "https://github.com/AdityaAnandCodes/M-Arcade"
 
 [[repo]]
 url = "https://github.com/AdityaKoranga/zkSync-prtocol_sample"
@@ -235,6 +250,9 @@ url = "https://github.com/AlbionaHoti/zksync-web-v2-docs"
 url = "https://github.com/AlcibiadesCleinias/crypto-zombies-course"
 
 [[repo]]
+url = "https://github.com/Aletheios42/Updraft_Cyfrin"
+
+[[repo]]
 url = "https://github.com/alexabstreiter/hackmoney"
 
 [[repo]]
@@ -248,6 +266,9 @@ url = "https://github.com/alexisljn/zksync-cryptozombies"
 
 [[repo]]
 url = "https://github.com/alexisljn/zksync-erc20-cryptozombies"
+
+[[repo]]
+url = "https://github.com/AlexNtolgkov/FundMe-Project"
 
 [[repo]]
 url = "https://github.com/Alexots/StandartStakeSwap"
@@ -360,7 +381,13 @@ url = "https://github.com/AntonChernyshev/zksync"
 url = "https://github.com/AntonChernyshev/zksync_script"
 
 [[repo]]
+url = "https://github.com/anuragShingare30/Solidity"
+
+[[repo]]
 url = "https://github.com/api3dao/chains"
+
+[[repo]]
+url = "https://github.com/arbdev95/foundry-fundme-f24.."
 
 [[repo]]
 url = "https://github.com/ArbitechSolution/airdropzksync"
@@ -384,6 +411,9 @@ url = "https://github.com/arin-paliwal/ThirdWeb-Contracts"
 url = "https://github.com/armanhm/Bachelor-project"
 
 [[repo]]
+url = "https://github.com/ArnaudBand/cyfrin_updraft_course"
+
+[[repo]]
 url = "https://github.com/Arogunb2021/z-k"
 
 [[repo]]
@@ -391,6 +421,9 @@ url = "https://github.com/ArpitIngle/Library-of-Ethereum"
 
 [[repo]]
 url = "https://github.com/ArshanKhanifar/zksync-greeter"
+
+[[repo]]
+url = "https://github.com/arthurvicente/portfolio"
 
 [[repo]]
 url = "https://github.com/arttartkhai/crypto-zombie"
@@ -466,6 +499,12 @@ url = "https://github.com/Babayevaterane/limit-order-settlement"
 url = "https://github.com/bacharif/aggregator"
 
 [[repo]]
+url = "https://github.com/BAHUBALI2550/NFT"
+
+[[repo]]
+url = "https://github.com/Ballantines87/AirdropSampleContract"
+
+[[repo]]
 url = "https://github.com/barackm/connectopiaa"
 
 [[repo]]
@@ -510,7 +549,13 @@ url = "https://github.com/beingofexistence/thirdweb-dashboard-web3"
 missing = true
 
 [[repo]]
+url = "https://github.com/benber86/vyper_tesseract_workshop"
+
+[[repo]]
 url = "https://github.com/Benuswers/figuras-del-futuro"
+
+[[repo]]
+url = "https://github.com/berekvolgyipeter/cyfrin-advanced-foundry-account-abstraction"
 
 [[repo]]
 url = "https://github.com/berkayermis/zkSync"
@@ -528,6 +573,9 @@ url = "https://github.com/betrox-gao/imtoken-h5-game"
 
 [[repo]]
 url = "https://github.com/BetSwirl/dimension-adapters"
+
+[[repo]]
+url = "https://github.com/BigTava/foundry-fundme"
 
 [[repo]]
 url = "https://github.com/biricik-eth/web"
@@ -626,6 +674,9 @@ url = "https://github.com/bxdoan/py-zkscan-api"
 url = "https://github.com/bxdoan/zksync-auto"
 
 [[repo]]
+url = "https://github.com/bxpana/Updraft"
+
+[[repo]]
 url = "https://github.com/bxpana/zkSync-Tips"
 
 [[repo]]
@@ -633,6 +684,15 @@ url = "https://github.com/bxpana/zksync-web-v2-docs"
 
 [[repo]]
 url = "https://github.com/bxpana/zksyncv2-local-setup"
+
+[[repo]]
+url = "https://github.com/bycraft-betrue/mox-algorithmic-trading-cu"
+
+[[repo]]
+url = "https://github.com/bycraft-betrue/mox-buy-me-a-coffee"
+
+[[repo]]
+url = "https://github.com/bycraft-betrue/mox-erc20-cu"
 
 [[repo]]
 url = "https://github.com/ByFishh/zk-flow"
@@ -706,6 +766,9 @@ url = "https://github.com/ChefBingbong/noti-api"
 url = "https://github.com/cheng-kang/hackmoney2022"
 
 [[repo]]
+url = "https://github.com/chenxu0602/foundry-f24"
+
+[[repo]]
 url = "https://github.com/chenxudongok/l2-intro-pre-ethdenver"
 
 [[repo]]
@@ -756,6 +819,9 @@ url = "https://github.com/clober-dex/core-zksync"
 url = "https://github.com/cmgoes/zigzag-frontend"
 
 [[repo]]
+url = "https://github.com/cnetten/foundry-fund-it"
+
+[[repo]]
 url = "https://github.com/coccoinomane/web3cli"
 
 [[repo]]
@@ -795,6 +861,9 @@ url = "https://github.com/CodeLarkin/evm-balance-checker"
 url = "https://github.com/codeTIT4N/zksync-example"
 
 [[repo]]
+url = "https://github.com/codypharm/airdrop"
+
+[[repo]]
 url = "https://github.com/CoffeeFam84/zksync-nft-promote"
 
 [[repo]]
@@ -820,6 +889,15 @@ url = "https://github.com/CosimoSguanci/Blockchain-Layer-2-Proof-of-Concept-App-
 
 [[repo]]
 url = "https://github.com/cosin2077/l2-intro-pre-ethdenver"
+
+[[repo]]
+url = "https://github.com/cosminmarian53/moccasin-portofolio-rebalance"
+
+[[repo]]
+url = "https://github.com/cosminmarian53/mox-stablecoin"
+
+[[repo]]
+url = "https://github.com/cosminmarian53/vyper-fund-me"
 
 [[repo]]
 url = "https://github.com/CoveMB/Sandbox--Hardhat"
@@ -917,7 +995,43 @@ url = "https://github.com/CyberCrowdOrg/CyberPay"
 missing = true
 
 [[repo]]
+url = "https://github.com/Cyfrin/ctf-vy"
+
+[[repo]]
+url = "https://github.com/Cyfrin/foundry-devops"
+
+[[repo]]
+url = "https://github.com/Cyfrin/foundry-erc20-cu"
+
+[[repo]]
+url = "https://github.com/Cyfrin/foundry-nft-cu"
+
+[[repo]]
+url = "https://github.com/Cyfrin/mox-algorithmic-trading-cu"
+
+[[repo]]
+url = "https://github.com/Cyfrin/mox-buy-me-a-coffee-cu"
+
+[[repo]]
+url = "https://github.com/Cyfrin/mox-erc20-cu"
+
+[[repo]]
+url = "https://github.com/Cyfrin/mox-favorites-cu"
+
+[[repo]]
+url = "https://github.com/Cyfrin/mox-nft-cu"
+
+[[repo]]
+url = "https://github.com/Cyfrin/mox-raffle-cu"
+
+[[repo]]
+url = "https://github.com/Cyfrin/mox-signatures-cu"
+
+[[repo]]
 url = "https://github.com/Cyfrin/sc-exploits-minimized"
+
+[[repo]]
+url = "https://github.com/Cyfrin/Updraft"
 
 [[repo]]
 url = "https://github.com/czarcoin/web"
@@ -931,7 +1045,13 @@ url = "https://github.com/czbaq/zksync"
 missing = true
 
 [[repo]]
+url = "https://github.com/D0pal/stableswap-ng"
+
+[[repo]]
 url = "https://github.com/D8-X/pyth-crosschain-d8x"
+
+[[repo]]
+url = "https://github.com/Dalois-30/foundry-erc-f23"
 
 [[repo]]
 url = "https://github.com/Damin-Lee/wagmi_chains_klaytn"
@@ -944,6 +1064,9 @@ url = "https://github.com/dangongeth/mi-zks"
 
 [[repo]]
 url = "https://github.com/danimbrogno/zksync-drewcoin"
+
+[[repo]]
+url = "https://github.com/danitome24/updraft-course-solidity"
 
 [[repo]]
 url = "https://github.com/dao-envelop/envelop-protocol-v1"
@@ -995,6 +1118,12 @@ url = "https://github.com/deadspyexx/airdrop-hunt-bot"
 url = "https://github.com/deadspyexx/dex-sniper-bot"
 
 [[repo]]
+url = "https://github.com/Decodeine/FundMe-Solidity-Contract"
+
+[[repo]]
+url = "https://github.com/DeepLinkProtocol/DeepLinkOrionMiningLongTermLeaseContract"
+
+[[repo]]
 url = "https://github.com/defi-pro/gmx-contracts-evmmode"
 
 [[repo]]
@@ -1041,6 +1170,12 @@ url = "https://github.com/developerfred/zksync"
 
 [[repo]]
 url = "https://github.com/devest-finance/dv-token"
+
+[[repo]]
+url = "https://github.com/DevJSter/advanced-foundry"
+
+[[repo]]
+url = "https://github.com/DevJSter/nft-collection"
 
 [[repo]]
 url = "https://github.com/DevRelMalima/zksync-african-tour"
@@ -1115,11 +1250,17 @@ url = "https://github.com/dorucioclea/web"
 url = "https://github.com/Dragonwarrior1234/zksync-smart-contract"
 
 [[repo]]
+url = "https://github.com/draju1980/solid-adventure"
+
+[[repo]]
 url = "https://github.com/drew7wonders/CrowdFunding"
 missing = true
 
 [[repo]]
 url = "https://github.com/droconnel22/Ethereum-Solidity-Collection"
+
+[[repo]]
+url = "https://github.com/dt6120/merkle-airdrop"
 
 [[repo]]
 url = "https://github.com/dtedesco1/zksync-example"
@@ -1156,6 +1297,12 @@ url = "https://github.com/dutterbutter/zksync-quickstart-guide"
 
 [[repo]]
 url = "https://github.com/duytonghai/testnet"
+
+[[repo]]
+url = "https://github.com/Dvisacker/evm-projects"
+
+[[repo]]
+url = "https://github.com/dxdw233/merkle-airdrop"
 
 [[repo]]
 url = "https://github.com/e-favela021/zksync-smart-contract-guide"
@@ -1204,6 +1351,9 @@ url = "https://github.com/elicharlese/eattheblocks-notes"
 url = "https://github.com/elysia-dev/reality-eth-monorepo"
 
 [[repo]]
+url = "https://github.com/emu-code/foundry-fund-me-pilot"
+
+[[repo]]
 url = "https://github.com/EngSiangTeo/charity-defi"
 
 [[repo]]
@@ -1239,6 +1389,12 @@ url = "https://github.com/ermyas/zksync-web-v2-docs"
 
 [[repo]]
 url = "https://github.com/ernestognw/zksync-uups-vault"
+
+[[repo]]
+url = "https://github.com/ervand7/Summary"
+
+[[repo]]
+url = "https://github.com/ErvinTyx/foundry-fundme-f23"
 
 [[repo]]
 url = "https://github.com/ethantddavis/sharing-sheets"
@@ -1343,6 +1499,9 @@ url = "https://github.com/flair-sdk/contracts"
 url = "https://github.com/flair-sdk/contracts-solidity"
 
 [[repo]]
+url = "https://github.com/floor-licker/moccasin"
+
+[[repo]]
 url = "https://github.com/FloorSweep/floorsweep"
 
 [[repo]]
@@ -1424,10 +1583,16 @@ url = "https://github.com/georgemac510/zksync-portfolio-token"
 missing = true
 
 [[repo]]
+url = "https://github.com/geraldwenzel/Updraft"
+
+[[repo]]
 url = "https://github.com/gg-big-org/hardhat-deploy"
 
 [[repo]]
 url = "https://github.com/ggonzalez94/hardhat-deploy"
+
+[[repo]]
+url = "https://github.com/gin/Updraft"
 
 [[repo]]
 url = "https://github.com/gitcoinco/BulkTransactions"
@@ -1452,6 +1617,9 @@ url = "https://github.com/glifio/defillama-server"
 
 [[repo]]
 url = "https://github.com/gluk64/zknft"
+
+[[repo]]
+url = "https://github.com/gmh5225/titanoboa-zksync"
 
 [[repo]]
 url = "https://github.com/GomerMagog/Magog"
@@ -1491,6 +1659,9 @@ url = "https://github.com/guidocazzaniga/zksync-examples"
 missing = true
 
 [[repo]]
+url = "https://github.com/GuireWire/python-vyper-mox-five-more"
+
+[[repo]]
 url = "https://github.com/gurrudev/HopeHarbor"
 
 [[repo]]
@@ -1509,6 +1680,9 @@ url = "https://github.com/harvestfi/harvest-front-v3"
 
 [[repo]]
 url = "https://github.com/harvestfi/harvest-strategy-zksync"
+
+[[repo]]
+url = "https://github.com/harystyleseze/foundry-devops"
 
 [[repo]]
 url = "https://github.com/Hash4Cashh/DropHacker"
@@ -1556,6 +1730,9 @@ url = "https://github.com/hoangghaii/Web3-Ethereum-Solidity"
 url = "https://github.com/holmenov/ZkSync-Transactions"
 
 [[repo]]
+url = "https://github.com/holtzin29/foundry-fund-me"
+
+[[repo]]
 url = "https://github.com/hooperben/lambda-zksync-masp"
 
 [[repo]]
@@ -1570,6 +1747,9 @@ url = "https://github.com/HyoungsungKim/HyoungsungKim.github.io"
 
 [[repo]]
 url = "https://github.com/iamasimkhan/Useful-Smart-Contracts"
+
+[[repo]]
+url = "https://github.com/iamnov1ce/erc20"
 
 [[repo]]
 url = "https://github.com/icii-dev/test-drop"
@@ -1785,7 +1965,13 @@ missing = true
 url = "https://github.com/JediKunnow/moneymates-contracts"
 
 [[repo]]
+url = "https://github.com/jennyg0/cyfrin-updraft-foundry"
+
+[[repo]]
 url = "https://github.com/jensenhertz/zkevm-alpha-boilerplate"
+
+[[repo]]
+url = "https://github.com/jestanoff/airdrop-merkle"
 
 [[repo]]
 url = "https://github.com/jgcogsystematictrading/zkAirnode"
@@ -1795,6 +1981,12 @@ url = "https://github.com/jhubbardsf/hardhat-deploy"
 
 [[repo]]
 url = "https://github.com/jiewpassakorn/fairfund"
+
+[[repo]]
+url = "https://github.com/jkn1092/egghead-contracts"
+
+[[repo]]
+url = "https://github.com/jmakwana01/Foundry_NFT"
 
 [[repo]]
 url = "https://github.com/jmoreira-ls/still-here"
@@ -1874,6 +2066,12 @@ url = "https://github.com/jrocca82/zksync"
 url = "https://github.com/jscode017/zksync_script"
 
 [[repo]]
+url = "https://github.com/juanc004/Foundry-FundMe-Project"
+
+[[repo]]
+url = "https://github.com/JuanPeVentura/Merkle-Airdrop"
+
+[[repo]]
 url = "https://github.com/julienbrg/zksync-minter"
 
 [[repo]]
@@ -1901,6 +2099,9 @@ url = "https://github.com/kakui-lau/maker-rule-tool"
 url = "https://github.com/kakui-lau/OrbiterFE-V2"
 
 [[repo]]
+url = "https://github.com/Kamyx001/fund-me-foundry"
+
+[[repo]]
 url = "https://github.com/karanthakur13/BlockFin"
 
 [[repo]]
@@ -1911,6 +2112,9 @@ url = "https://github.com/kariy/zksync-contracts"
 
 [[repo]]
 url = "https://github.com/karolsudol/hello-zksync"
+
+[[repo]]
+url = "https://github.com/KartikC137/Smart-Contract-Development"
 
 [[repo]]
 url = "https://github.com/kavithashanmugan/zkSync"
@@ -1961,6 +2165,12 @@ url = "https://github.com/Kizliak/zksync-lite-farmer"
 
 [[repo]]
 url = "https://github.com/klever-io/rotki"
+
+[[repo]]
+url = "https://github.com/KMean/cyfrin-updraft-merkle-airdrop"
+
+[[repo]]
+url = "https://github.com/kobayashi1987/smartcontract"
 
 [[repo]]
 url = "https://github.com/kopy-kat/ethdenver-aa"
@@ -2015,6 +2225,9 @@ url = "https://github.com/lambdaclass/zksync_l3_poc"
 url = "https://github.com/lambdaclass/zksync_seaport"
 
 [[repo]]
+url = "https://github.com/LanceAddison/foundry-fund-me-f23"
+
+[[repo]]
 url = "https://github.com/Larkooo/onpeer"
 
 [[repo]]
@@ -2060,6 +2273,9 @@ url = "https://github.com/light-fury/usedapp-master"
 url = "https://github.com/ligulfzhou/zksync-farmer"
 
 [[repo]]
+url = "https://github.com/lIlIlIlIIlIlIlIlI/Updraft"
+
+[[repo]]
 url = "https://github.com/liling0509/zksync-li"
 
 [[repo]]
@@ -2103,6 +2319,9 @@ missing = true
 
 [[repo]]
 url = "https://github.com/Logic1710/Project-AAG"
+
+[[repo]]
+url = "https://github.com/loki1512/TDS-Project-1"
 
 [[repo]]
 url = "https://github.com/longdh210/evb-smart-contracts"
@@ -2220,6 +2439,9 @@ url = "https://github.com/MarkuSchick/hardhat-deploy"
 [[repo]]
 url = "https://github.com/MarkuSchick/zksync-vyper-test"
 missing = true
+
+[[repo]]
+url = "https://github.com/marvy-codes/Fundry-f23"
 
 [[repo]]
 url = "https://github.com/mateuszmaczynski/Pets-Shop"
@@ -3554,6 +3776,9 @@ url = "https://github.com/mio256/zkSync-python"
 url = "https://github.com/mirza-sync/connect-metamask"
 
 [[repo]]
+url = "https://github.com/mishraji874/moccasin-five-more"
+
+[[repo]]
 url = "https://github.com/Mister-Eth/CryptoTPS"
 
 [[repo]]
@@ -3594,6 +3819,9 @@ missing = true
 url = "https://github.com/monishkajha17/thirdweb-contracts"
 
 [[repo]]
+url = "https://github.com/monmon-sitdown/foundry-nft"
+
+[[repo]]
 url = "https://github.com/Moonsong-Labs/era-l1-upgrade-checker"
 
 [[repo]]
@@ -3622,11 +3850,17 @@ url = "https://github.com/moskalyk/zksync-l2-urbit-sequencer"
 url = "https://github.com/mpavlovic-txfusion/zksync-web-v2-docs"
 
 [[repo]]
+url = "https://github.com/mpeyfuss/gaboon-test"
+
+[[repo]]
 url = "https://github.com/mpopovac-txfusion/zksync-web-v2-docs"
 
 [[repo]]
 url = "https://github.com/Mr-mogambo/monorepo-1"
 missing = true
+
+[[repo]]
+url = "https://github.com/MRAlirad/foundry-fund-me"
 
 [[repo]]
 url = "https://github.com/MrBloomguy/YouBuidl-ZKsync"
@@ -3646,6 +3880,9 @@ url = "https://github.com/mtiutin/ETHLisbon-2022-hackathon"
 
 [[repo]]
 url = "https://github.com/MUFEX-Exchange/smart-contract"
+
+[[repo]]
+url = "https://github.com/muhammadjehanzaib/merkleAirdrop"
 
 [[repo]]
 url = "https://github.com/mukesh5/simple-l2-zksync-AMM"
@@ -3765,6 +4002,9 @@ url = "https://github.com/nick07002/zkSyncEraContractExample"
 url = "https://github.com/nicobevilacqua/zksync-web-v2-docs"
 
 [[repo]]
+url = "https://github.com/nicolasguasca1/cyfrin_updraft_advanced_foundry"
+
+[[repo]]
 url = "https://github.com/nieznanysprawiciel/ya-zksync-prover"
 
 [[repo]]
@@ -3790,6 +4030,9 @@ url = "https://github.com/nonstopcoderaxw/zk-electronic-signature"
 
 [[repo]]
 url = "https://github.com/nopslip/web"
+
+[[repo]]
+url = "https://github.com/Not-Sarthak/merkle-airdrop"
 
 [[repo]]
 url = "https://github.com/novusys/novusys-paymaster"
@@ -3850,6 +4093,9 @@ url = "https://github.com/onetxpunch/zksync-era-hardhat-template"
 url = "https://github.com/onionpeel/basic-aa"
 
 [[repo]]
+url = "https://github.com/onkarmore26/NFT"
+
+[[repo]]
 url = "https://github.com/ONtio-js/blockchain-crowdfunding-platform"
 
 [[repo]]
@@ -3883,6 +4129,9 @@ missing = true
 
 [[repo]]
 url = "https://github.com/osarukun/web"
+
+[[repo]]
+url = "https://github.com/oslinin/solidity"
 
 [[repo]]
 url = "https://github.com/ospinooo/solidity-notes"
@@ -4049,6 +4298,12 @@ url = "https://github.com/pradhuman-chhabra/emttr-zksync"
 url = "https://github.com/prajjwalsuhane/Crowdfunding-Website"
 
 [[repo]]
+url = "https://github.com/PranavLakkadi13/Foundry-Airdrop"
+
+[[repo]]
+url = "https://github.com/PRANJALRANA11/foundry-lottery"
+
+[[repo]]
 url = "https://github.com/predyprotocol/defillama-server"
 
 [[repo]]
@@ -4182,6 +4437,9 @@ url = "https://github.com/rhinofi/contracts_public"
 url = "https://github.com/rhinofi/defillama-server"
 
 [[repo]]
+url = "https://github.com/ricardomazuera/merkle-airdrop"
+
+[[repo]]
 url = "https://github.com/richardjhong/tokenraffle"
 
 [[repo]]
@@ -4234,6 +4492,9 @@ url = "https://github.com/RutvikGujarati/landRegistry"
 url = "https://github.com/ryu666zaki/zkSync-Bridger"
 
 [[repo]]
+url = "https://github.com/s3bc40/mox-algorithmic-trading-cu"
+
+[[repo]]
 url = "https://github.com/sade-c/zksync-web3-starter"
 
 [[repo]]
@@ -4278,11 +4539,20 @@ url = "https://github.com/samueldanso/zksync-greeter-example"
 url = "https://github.com/sangbejo/sismo"
 
 [[repo]]
+url = "https://github.com/Sanvaad/Foundry-fund-me"
+
+[[repo]]
 url = "https://github.com/SARNAVOSS/MedSecure_Blockchain-Backend-"
 missing = true
 
 [[repo]]
 url = "https://github.com/Satis-Foundation/Satis-core"
+
+[[repo]]
+url = "https://github.com/satyasai69/merkle-airdrop"
+
+[[repo]]
+url = "https://github.com/satyasai69/minimal-account-abstraction"
 
 [[repo]]
 url = "https://github.com/scaling-eth-2023/wallet-extension"
@@ -4307,6 +4577,9 @@ url = "https://github.com/seanbhart/y-v1-core"
 
 [[repo]]
 url = "https://github.com/SeanTan7150/hardhat-web3-project"
+
+[[repo]]
+url = "https://github.com/SeanXLChen/foundry-crowdsource-project"
 
 [[repo]]
 url = "https://github.com/sebastianbarkan/Nodify"
@@ -4342,6 +4615,9 @@ url = "https://github.com/ShishiraB/FundVerse"
 
 [[repo]]
 url = "https://github.com/shivanshxyz/hello-zksync"
+
+[[repo]]
+url = "https://github.com/shoaib-eth/foundry-abstractify-accounts-f24"
 
 [[repo]]
 url = "https://github.com/ShobhanSrivastava/Flipkart-Grid5.0"
@@ -4394,6 +4670,12 @@ url = "https://github.com/sidrisov/payflow"
 
 [[repo]]
 url = "https://github.com/SilkyFinance1/skyContracts"
+
+[[repo]]
+url = "https://github.com/Silverguilt/foundry-first-repo"
+
+[[repo]]
+url = "https://github.com/Sim-Security/Merkle-Airdrop"
 
 [[repo]]
 url = "https://github.com/simon-perriard/zkSync2.0_playground"
@@ -4499,6 +4781,9 @@ url = "https://github.com/spyglassventures/signaseal"
 
 [[repo]]
 url = "https://github.com/sripwoud/zksync-cli-playground"
+
+[[repo]]
+url = "https://github.com/ssabrut/fund-me"
 
 [[repo]]
 url = "https://github.com/ssghost/zksync-test"
@@ -4656,6 +4941,9 @@ url = "https://github.com/taylorjdawson/eth-chains"
 url = "https://github.com/temptemp3/web"
 
 [[repo]]
+url = "https://github.com/teodorstupnicki/foundry-fm"
+
+[[repo]]
 url = "https://github.com/tevaera-labs/contracts"
 
 [[repo]]
@@ -4692,6 +4980,9 @@ url = "https://github.com/tiagokin/zksync-era"
 
 [[repo]]
 url = "https://github.com/tiancai110a/blockchain_study"
+
+[[repo]]
+url = "https://github.com/tianqizhao-louis/foundry-fund-me"
 
 [[repo]]
 url = "https://github.com/tiennampham23/syncswap-sdk"
@@ -4815,6 +5106,9 @@ url = "https://github.com/tz8899/zksyncbot-ashubot"
 url = "https://github.com/tztokln/ZombieFactory"
 
 [[repo]]
+url = "https://github.com/uddercover/foundry-merkle-airdrop-f23"
+
+[[repo]]
 url = "https://github.com/uF4No/0x-compile"
 
 [[repo]]
@@ -4896,6 +5190,9 @@ missing = true
 url = "https://github.com/uri1001/the-evm-networks-project"
 
 [[repo]]
+url = "https://github.com/usgeeus/mox-algorithmic-trading"
+
+[[repo]]
 url = "https://github.com/ustas-eth/zkEVM-Bootcamp"
 
 [[repo]]
@@ -4963,6 +5260,9 @@ url = "https://github.com/vikkkko/zksyncM"
 
 [[repo]]
 url = "https://github.com/vile/zksync-allocation-checker"
+
+[[repo]]
+url = "https://github.com/vincelaird/foundry-merkle-airdrop"
 
 [[repo]]
 url = "https://github.com/vinhbhn/zk"
@@ -5044,6 +5344,12 @@ url = "https://github.com/webdevbiv/web3"
 missing = true
 
 [[repo]]
+url = "https://github.com/weiweiyeih/mox-buy-me-a-coffee-cu"
+
+[[repo]]
+url = "https://github.com/weiweiyeih/mox-ec20-cu"
+
+[[repo]]
 url = "https://github.com/wesleyt95/TechClub"
 missing = true
 
@@ -5062,6 +5368,9 @@ url = "https://github.com/William3Johnson/redesigned-succotash"
 
 [[repo]]
 url = "https://github.com/William3Johnson/yagna-zksync"
+
+[[repo]]
+url = "https://github.com/WillStansill/Foundry-Merkle-Airdrop"
 
 [[repo]]
 url = "https://github.com/WIM3/protocol"
@@ -5127,6 +5436,9 @@ missing = true
 url = "https://github.com/XUAN980625/P2E-GAME"
 
 [[repo]]
+url = "https://github.com/xyizko/Updraft"
+
+[[repo]]
 url = "https://github.com/Y-Min13/zkSyncEra_2"
 missing = true
 
@@ -5139,6 +5451,12 @@ url = "https://github.com/yasharma02/jombies"
 [[repo]]
 url = "https://github.com/yasp-fi/models"
 missing = true
+
+[[repo]]
+url = "https://github.com/ybtuti/vyper-cu"
+
+[[repo]]
+url = "https://github.com/yeahChibyke/Hugs-Merkle-Airdrop"
 
 [[repo]]
 url = "https://github.com/Yilian111/eraaoz"
@@ -5261,6 +5579,9 @@ url = "https://github.com/zhidou/ethonline"
 [[repo]]
 url = "https://github.com/zhonglinlynn/matter-lab-zksync"
 missing = true
+
+[[repo]]
+url = "https://github.com/zhouhangmyers/Foundry-NFT-Puggy"
 
 [[repo]]
 url = "https://github.com/Zigmod/test4"


### PR DESCRIPTION
The following repositories are using either (or both) of the following tools:

- [zksyncchainchecker](https://github.com/Cyfrin/foundry-devops)
- [titanoboa-zksync](https://github.com/vyperlang/titanoboa-zksync)

Due to this, they should be included in the ZKsync ecosystem. 