### PR TITLE
Add DexKit monorepo repository

### DIFF
--- a/data/ecosystems/d/dexkit.toml
+++ b/data/ecosystems/d/dexkit.toml
@@ -55,6 +55,9 @@ url = "https://github.com/DexKit/dexkit-evm-chains"
 url = "https://github.com/DexKit/dexkit-open-monorepo"
 
 [[repo]]
+url = "https://github.com/DexKit/dexkit-monorepo"
+
+[[repo]]
 url = "https://github.com/DexKit/dexkit-token-graph"
 
 [[repo]]


### PR DESCRIPTION
To include [DexAppBuiler monorepo](https://github.com/DexKit/dexkit-monorepo), now open source.