### PR TITLE
add SShift GPT project

### DIFF
--- a/data/ecosystems/a/aptos.toml
+++ b/data/ecosystems/a/aptos.toml
@@ -58,6 +58,7 @@ sub_ecosystems = [
   "Snotra",
   "Souffl3",
   "SpikaApp",
+  "SShift GPT",
   "Stader Labs",
   "Supervillain Labs",
   "Switchboard",
@@ -18753,6 +18754,9 @@ url = "https://github.com/ZXC-zxc/Aptos-web-test-tool"
 
 [[repo]]
 url = "https://github.com/zxf000000/aptos-tools-frontend"
+
+[[repo]]
+url = "https://github.com/CryptoAutistic80/sshift-gpt-app"
 
 [[repo]]
 url = "https://github.com/Zy-jay/swap"


### PR DESCRIPTION
Adding SShift GPT Project to aptos ecosystem

web app: https://sshiftgpt.com
gitbook: https://sshiftgpt.gitbook.io/sshiftgpt

