### PR TITLE
Add Zapier-Algorand to GoPlausible and Algorand

### DIFF
--- a/data/ecosystems/a/algorand.toml
+++ b/data/ecosystems/a/algorand.toml
@@ -6749,6 +6749,9 @@ url = "https://github.com/GoPlausible/algorand-mcp"
 url = "https://github.com/GoPlausible/algorand-qrcode"
 
 [[repo]]
+url = "https://github.com/GoPlausible/zapier-algorand"
+
+[[repo]]
 url = "https://github.com/GoracleNetwork/algokit_default_template"
 
 [[repo]]

--- a/data/ecosystems/g/goplausible.toml
+++ b/data/ecosystems/g/goplausible.toml
@@ -14,3 +14,6 @@ url = "https://github.com/GoPlausible/algorand-mcp"
 
 [[repo]]
 url = "https://github.com/GoPlausible/algorand-qrcode"
+
+[[repo]]
+url = "https://github.com/GoPlausible/zapier-algorand"


### PR DESCRIPTION
Add [Zapier-Algorand ](https://github.com/GoPlausible/zapier-algorand) repository to GoPlausible and Algorand.