### PR TITLE
Add Walletbeat.

### DIFF
--- a/data/ecosystems/w/walletbeat.toml
+++ b/data/ecosystems/w/walletbeat.toml
@@ -1,0 +1,17 @@
+# Ecosystem Level Information
+title = "Walletbeat"
+
+sub_ecosystems = []
+
+github_organizations = ["https://github.com/walletbeat"]
+
+# Repositories
+
+# Legacy version
+[[repo]]
+url = "https://github.com/fluidkey/walletbeat"
+
+# New version
+[[repo]]
+url = "https://github.com/walletbeat/walletbeat"
+tags = ["Website"]


### PR DESCRIPTION
Walletbeat aims to be the L2BEAT of wallets.

Site: https://walletbeat.fyi

Beta version (hosted in the `beta` branch of the fluidkey repo and being moved to its own org): https://beta.walletbeat.eth.limo