### PR TITLE
chore: add repos related to Filecoin

### DIFF
--- a/data/ecosystems/f/filecoin.toml
+++ b/data/ecosystems/f/filecoin.toml
@@ -4142,16 +4142,25 @@ url = "https://github.com/filbugs/lotus"
 missing = true
 
 [[repo]]
-url = "https://github.com/FILCAT/client-contract"
+url = "https://github.com/FilOzone/client-contract"
 
 [[repo]]
-url = "https://github.com/FILCAT/dagparts"
+url = "https://github.com/FilOzone/dagparts"
 
 [[repo]]
-url = "https://github.com/FILCAT/FilForwarder"
+url = "https://github.com/FilOzone/FilForwarder"
 
 [[repo]]
-url = "https://github.com/FILCAT/ribs"
+url = "https://github.com/FilOzone/ribs"
+
+[[repo]]
+url = "https://github.com/FilOzone/pdp-explorer"
+
+[[repo]]
+url = "https://github.com/FilOzone/pdp"
+
+[[repo]]
+url = "https://github.com/FilOzone/payments"
 
 [[repo]]
 url = "https://github.com/filchive/filchive"


### PR DESCRIPTION
Add some new contract repos related to Filecoin:
- PDP-Explorer
- PDP
- Payments

Fix link on some older links, as FILCAT org changed name to FilOzone