### PR TITLE
add TriggerX sub ecosystem under EigenLayer

### DIFF
--- a/migrations/2025-05-28T140404_mutations
+++ b/migrations/2025-05-28T140404_mutations
@@ -1,0 +1,5 @@
+--TriggerX is an automation protocol AVS under development on EigenLayer platform
+ecoadd TriggerX
+ecocon EigenLayer TriggerX
+repadd TriggerX https://github.com/trigg3rX/triggerx-backend #infrastructure
+repadd TriggerX https://github.com/trigg3rX/triggerx-contracts #smart-contract


### PR DESCRIPTION
TriggerX is an automation protocol AVS under development on EigenLayer platform. You can know more about us [here](https://www.triggerx.network/).