### PR TITLE
add Speedrun Stylus ecosystem under Arbitrum

### DIFF
--- a/migrations/2025-05-28T175324_mutations
+++ b/migrations/2025-05-28T175324_mutations
@@ -1,5 +1,5 @@
 --Speedrun Stylus is a developer onboarding and engagement platform for Rust and Web2 developers transitioning to Web3 using Arbitrum Stylus.
-ecoadd Speedrun Stylus
-ecocon Arbitrum Speedrun Stylus
-repadd Speedrun Stylus https://github.com/abhi152003/speedrun-stylus
-repadd Speedrun Stylus https://github.com/abhi152003/speedrun_stylus
+ecoadd "Speedrun Stylus"
+ecocon Arbitrum "Speedrun Stylus"
+repadd "Speedrun Stylus" https://github.com/abhi152003/speedrun-stylus
+repadd "Speedrun Stylus" https://github.com/abhi152003/speedrun_stylus


### PR DESCRIPTION
Speedrun Stylus is a developer onboarding and engagement platform for Rust and Web2 developers transitioning to Web3 using Arbitrum Stylus.