### PR TITLE
Add Noir + Aztec repos by wamimi to ecosystem

### DIFF
--- a/migrations/2025-06-27T152000_add_wamimi_aztec_projects
+++ b/migrations/2025-06-27T152000_add_wamimi_aztec_projects
@@ -1,0 +1,4 @@
+repadd "Noir Lang" https://github.com/wamimi/aztec-counter-contract #zkp #aztec
+repadd "Noir Lang" https://github.com/wamimi/zk-agerange-proof #zkp #aztec
+repadd "Noir Lang" https://github.com/wamimi/noir-zk-math-proof #zkp #aztec
+repadd "Noir Lang" https://github.com/wamimi/proof-of-wednesday-zk-sessions #zkp #aztec


### PR DESCRIPTION
This PR adds four open-source projects built with Noir and Aztec to the Electric Capital ecosystem tracker. These include zk apps and learning resources focused on zero-knowledge proofs. Repos are tagged under both the Aztec and NoirLang ecosystems.
Thanks