### PR TITLE
Add Noir-Circuit-Verifier-Example-with-Solidity-and-Foundry

### DIFF
--- a/migrations/2025-06-25T015300_add_zk_age_verification
+++ b/migrations/2025-06-25T015300_add_zk_age_verification
@@ -1,0 +1,5 @@
+-- Add NoirLang ecosystem if not already added
+ecoadd NoirLang
+
+-- Add your zk-age-verification repo to NoirLang
+repadd NoirLang https://github.com/cypriansakwa/zk-age-verification #zkp #age-check

--- a/migrations/2025-06-30T180000_add_noir_circuit_verifier_example
+++ b/migrations/2025-06-30T180000_add_noir_circuit_verifier_example
@@ -1,0 +1,1 @@
+repadd "Noir Lang" https://github.com/cypriansakwa/Noir-Circuit-Verifier-Example-with-Solidity-and-Foundry #zkp #noir #circuit #solidity #foundry


### PR DESCRIPTION
This migration adds the following Noir-based repository to the `Noir Lang` ecosystem:

- https://github.com/cypriansakwa/Noir-Circuit-Verifier-Example-with-Solidity-and-Foundry  
  A complete example showing how to generate a zero-knowledge proof in Noir, and verify it on-chain using Solidity and Foundry.

**Tags:** `#zkp` `#noir` `#circuit` `#solidity` `#foundry`
