### PR TITLE
Added new repo for algo git squad - ARC69 NFT Minting DApp

### DIFF
--- a/migrations/2025-07-04T182057_algorand_updates
+++ b/migrations/2025-07-04T182057_algorand_updates
@@ -1,0 +1,1 @@
+repadd Algorand https://github.com/VJLIVE/Algorand-ARC69-NFT-Minting-DApp


### PR DESCRIPTION
Added new repo for Algo Git Squad - [ARC69 NFT Minting DApp](https://github.com/VJLIVE/Algorand-ARC69-NFT-Minting-DApp)