### PR TITLE
Add noir_zkp_bounds_check ecosystem with Noir ZKP bounds check

### DIFF
--- a/migrations/2025-07-07T182400_add_noir_zkp_bounds_check
+++ b/migrations/2025-07-07T182400_add_noir_zkp_bounds_check
@@ -1,0 +1,1 @@
+repadd "Noir Lang" https://github.com/cypriansakwa/noir_zkp_bounds_check #example #zkp #zk-circuit#noir

--- a/migrations/2025-07-07T182400_add_noir_zkp_bounds_check
+++ b/migrations/2025-07-07T182400_add_noir_zkp_bounds_check
@@ -1,1 +1,1 @@
-repadd "Noir Lang" https://github.com/cypriansakwa/noir_zkp_bounds_check #example #zkp #zk-circuit#noir
+repadd "Noir Lang" https://github.com/cypriansakwa/noir_zkp_bounds_check #example #zkp #zk-circuit #noir


### PR DESCRIPTION
Adds a new Noir example project for noir zkp bounds check  to the "Noir Lang" ecosystem.
	
	Repository: https://github.com/cypriansakwa/noir_zkp_bounds_check
	Tags: #example #zkp #zk-circuit #noir
	
	Data Source: Electric Capital Crypto Ecosystems
	
	If you're working in open source crypto, submit your repository here to be counted.