### PR TITLE
Add Repos to Algorand Ecosystem

### DIFF
--- a/migrations/2025-07-08T235959_algorand_updates
+++ b/migrations/2025-07-08T235959_algorand_updates
@@ -1,0 +1,3 @@
+ecocon Algorand GoPlausible
+repadd Algorand https://github.com/GoPlausible/algorand-remote-mcp
+repadd Algorand https://github.com/ultrade-org/ultrade-mcp


### PR DESCRIPTION
Add two repositories to Algorand ecosystem and connecting GoPlausible as a child to Algorand ecosystem.
- [Algorand Remote MCP](https://github.com/GoPlausible/algorand-remote-mcp)
- [Ultrade MCP](https://github.com/ultrade-org/ultrade-mcp)

