### PR TITLE
Add PayDece P2P escrow to Polygon and Base networks

### DIFF
--- a/migrations/2025-07-09T234259_paydece_updates
+++ b/migrations/2025-07-09T234259_paydece_updates
@@ -1,0 +1,5 @@
+-- PayDece multi-chain expansion updates
+-- Adding PayDece P2P escrow smart contracts to new chains: Polygon and Base
+-- PayDece already exists in Ethereum, BNB Chain, and Hardhat from previous migrations
+repadd Polygon https://github.com/PayDece/paydece-contracts #escrow
+repadd Base https://github.com/PayDece/paydece-contracts #escrow 


### PR DESCRIPTION
## Summary
   This PR adds PayDece P2P escrow smart contracts to Polygon and Base ecosystems.

   ## About PayDece
   - **Project**: PayDece (https://paydece.io)
   - **Type**: Peer-to-peer escrow system for secure transactions
   - **Repository**: https://github.com/PayDece/paydece-contracts
   - **Audit**: Audited by Hacken (https://hacken.io/audits/paydece/)

   ## Changes
   - ✅ Added PayDece to **Polygon** ecosystem with `#escrow` tag
   - ✅ Added PayDece to **Base** ecosystem with `#escrow` tag
   - ℹ️ PayDece already exists in Ethereum, BNB Chain, and Hardhat from previous migrations

   ## Migration File
   - `migrations/2025-07-09T234259_paydece_updates`