### PR TITLE
Add Noir ZKModExpCircuit Example Project to Ecosystem

### DIFF
--- a/migrations/2025-07-14T221500_add-ZKModExpCircuit
+++ b/migrations/2025-07-14T221500_add-ZKModExpCircuit
@@ -1,0 +1,1 @@
+repadd "Noir Lang" https://github.com/cypriansakwa/ZKModExpCircuit #example #zkp #ZKModExpCircuit #noir


### PR DESCRIPTION
Adds a new Noir example project for modular exponentiation (ZKModExpCircuit) to the Noir Lang ecosystem.
	
	Repository: https://github.com/cypriansakwa/ZKModExpCircuit
	Tags: #example #zkp #ZKModExpCircuit #noir
	
	Data Source: Electric Capital Crypto Ecosystems
	
	If you're working in open source crypto, submit your repository here to be counted.