### PR TITLE
Add ZK_Aggregated_Credential_Score circuit to the Noir Lang ecosystem

### DIFF
--- a/migrations/2025-07-15T060300_add-ZK_Aggregated_Credential_Score
+++ b/migrations/2025-07-15T060300_add-ZK_Aggregated_Credential_Score
@@ -1,0 +1,1 @@
+repadd "Noir Lang" https://github.com/cypriansakwa/ZK_Aggregated_Credential_Score #example #zkp #ZK_Aggregated_Credential_Score #noir


### PR DESCRIPTION
Adds ZK_Aggregated_Credential_Score circuit to the "Noir Lang" ecosystem.
	This PR introduces a new zero-knowledge proof circuit named ZK_Aggregated_Credential_Score to the Noir Lang ecosystem.
	Repository: https://github.com/cypriansakwa/ZK_Aggregated_Credential_Score
	Tags: #example #zkp #ZK_Aggregated_Credential_Score #noir
	
	Data Source: Electric Capital Crypto Ecosystems
	
	If you're working in open source crypto, submit your repository here to be counted.