### PR TITLE
Add noir_pedersen_bits16 project to the Noir Lang ecosystem

### DIFF
--- a/migrations/2025-07-15T225000_add-noir_pedersen_bits16
+++ b/migrations/2025-07-15T225000_add-noir_pedersen_bits16
@@ -1,0 +1,1 @@
+repadd "Noir Lang" https://github.com/cypriansakwa/noir_pedersen_bits16 #example #zkp  #zk-circuit #noir #aztec #noir_pedersen_bits16 


### PR DESCRIPTION
Adds the noir_pedersen_bits16 project to the "Noir Lang" ecosystem.
	
	Repository: https://github.com/cypriansakwa/noir_pedersen_bits16
	Tags: #example #zkp  #zk-circuit #noir #aztec #noir_pedersen_bits16
	
	Data Source: Electric Capital Crypto Ecosystems
	
	If you're working in open source crypto, submit your repository here to be counted.