### PR TITLE
Add noir_base64_integration project to the Noir Lang ecosystem

### DIFF
--- a/migrations/2025-07-16T002600_add-noir_base64_integration
+++ b/migrations/2025-07-16T002600_add-noir_base64_integration
@@ -1,0 +1,1 @@
+repadd "Noir Lang" https://github.com/cypriansakwa/noir_base64_integration #example #zkp #zk-circuit #noir #aztec #noir_base64_integration


### PR DESCRIPTION
Adds the noir_base64_integration project to the "Noir Lang" ecosystem.
	
	Repository: https://github.com/cypriansakwa/noir_base64_integration
	Tags: #example #zkp #zk-circuit #noir
	
	Data Source: Electric Capital Crypto Ecosystems
	
	If you're working in open source crypto, submit your repository here to be counted.