### PR TITLE
Add zkp_pedersen_range_safe project to the Noir Lang ecosystem

### DIFF
--- a/migrations/2025-07-16T234200_add-zkp_pedersen_range_safe
+++ b/migrations/2025-07-16T234200_add-zkp_pedersen_range_safe
@@ -1,0 +1,1 @@
+repadd "Noir Lang" https://github.com/cypriansakwa/zkp_pedersen_range_safe #example #zkp  #zk-circuit #noir #aztec


### PR DESCRIPTION
Adds the zkp_pedersen_range_safe project to the "Noir Lang" ecosystem. 
	
	Repository: https://github.com/cypriansakwa/zkp_pedersen_range_safe
	Tags: #zkp #zk-circuit #noir #aztec #example 
	
	Data Source: Electric Capital Crypto Ecosystems
	
	If you're working in open source crypto, submit your repository here to be counted.