### PR TITLE
Add noir_modular_exponentiation circuit to the Noir Lang ecosystem

### DIFF
--- a/migrations/2025-07-17T092000_add-noir_modular_exponentiation
+++ b/migrations/2025-07-17T092000_add-noir_modular_exponentiation
@@ -1,0 +1,1 @@
+repadd "Noir Lang" https://github.com/cypriansakwa/noir_modular_exponentiation #example #zkp  #zk-circuit #noir #aztec


### PR DESCRIPTION
Adds the noir_modular_exponentiation circuit to the "Noir Lang" ecosystem. 
	
	Repository: https://github.com/cypriansakwa/noir_modular_exponentiation
	Tags: #zkp #zk-circuit #noir #aztec
	
	Data Source: Electric Capital Crypto Ecosystems
	
	If you're working in open source crypto, submit your repository here to be counted.