### PR TITLE
Add noir_private_matrix_proof project to the Noir Lang ecosystem

### DIFF
--- a/migrations/2025-07-22T063400_add-noir_private_matrix_proof
+++ b/migrations/2025-07-22T063400_add-noir_private_matrix_proof
@@ -1,0 +1,1 @@
+repadd "Noir Lang" https://github.com/cypriansakwa/noir_private_matrix_proof #example #zkp  #zk-circuit #noir #aztec


### PR DESCRIPTION
Adds a new Noir example project: noir_private_matrix_proof the "Noir Lang" ecosystem.
	
Repository: https://github.com/cypriansakwa/noir_private_matrix_proof 
Tags: #zkp #zk-circuit #noir #aztec
	
Data Source: Electric Capital Crypto Ecosystems
	
If you're working in open source crypto, submit your repository here to be counted.