### PR TITLE
Add noir-base64-howto project to the Noir Lang ecosystem

### DIFF
--- a/migrations/2025-07-26T081200_add-noir-base64-howto
+++ b/migrations/2025-07-26T081200_add-noir-base64-howto
@@ -1,0 +1,1 @@
+repadd "Noir Lang" https://github.com/cypriansakwa/noir-base64-howto #zkp  #zk-circuit #noir #aztec #base64


### PR DESCRIPTION
Adds a new Noir example project for the noir-base64-howto project to the "Noir Lang" ecosystem. 
	
Repository: https://github.com/cypriansakwa/noir-base64-howto
Tags: #zkp  #zk-circuit #noir #aztec #base64

	
Data Source: Electric Capital Crypto Ecosystems
	
If you're working in open source crypto, submit your repository here to be counted.