### PR TITLE
Add 18 new forks for Algorand Web3 Masterclasses (new migration)

### DIFF
--- a/migrations/2025-08-26T110000_add_algorand_masterclasses_new_repos
+++ b/migrations/2025-08-26T110000_add_algorand_masterclasses_new_repos
@@ -1,0 +1,24 @@
+-- Add new forks (Aug 26, 2025) for Algorand Web3 Masterclasses projects
+-- Tag: #developer-tool
+
+-- POC Template Algorand Web3 Masterclasses (17 new)
+repadd Algorand https://github.com/a4fn/POC-Template-Algorand-Web3-Masterclasses #developer-tool
+repadd Algorand https://github.com/arrowzip/POC-Template-Algorand-Web3-Masterclasses #developer-tool
+repadd Algorand https://github.com/Ayodelesammylee/POC-Template-Algorand-Web3-Masterclasses #developer-tool
+repadd Algorand https://github.com/CABreedt/POC-Template-Algorand-Web3-Masterclasses #developer-tool
+repadd Algorand https://github.com/camohe90/POC-Template-Algorand-Web3-Masterclasses #developer-tool
+repadd Algorand https://github.com/chriskrim2002/POC-Template-Algorand-Web3-Masterclasses #developer-tool
+repadd Algorand https://github.com/Corly23/POC-Template-Algorand-Web3-Masterclasses #developer-tool
+repadd Algorand https://github.com/DWMcG/POC-Template-Algorand-Web3-Masterclasses #developer-tool
+repadd Algorand https://github.com/Edda-Ignite/POC-Template-Algorand-Web3-Masterclasses #developer-tool
+repadd Algorand https://github.com/eskizolibereco/POC-Template-Algorand-Web3-Masterclasses #developer-tool
+repadd Algorand https://github.com/Nijichan/POC-Template-Algorand-Web3-Masterclasses #developer-tool
+repadd Algorand https://github.com/pranavasati28/POC-Template-Algorand-Web3-Masterclasses #developer-tool
+repadd Algorand https://github.com/SalmanOkz/POC-Template-Algorand-Web3-Masterclasses #developer-tool
+repadd Algorand https://github.com/Shamsejaz/POC-Template-Algorand-Web3-Masterclasses #developer-tool
+repadd Algorand https://github.com/UbGreat/POC-Template-Algorand-Web3-Masterclasses #developer-tool
+repadd Algorand https://github.com/vickijay01/POC-Template-Algorand-Web3-Masterclasses #developer-tool
+repadd Algorand https://github.com/vickijay103/POC-Template-Algorand-Web3-Masterclasses #developer-tool
+
+-- Algorand Web3 Masterclasses POC (1 new)
+repadd Algorand https://github.com/HaiderAziz428/Algorand-Web3-Masterclasses-POC #developer-tool


### PR DESCRIPTION
Adds 18 newly forked repos for Algorand Web3 Masterclasses as a separate migration file,
per reviewer guidance. All tagged #developer-tool.

- POC Template Algorand Web3 Masterclasses: +17 forks
- Algorand Web3 Masterclasses POC: +1 fork 
