### PR TITLE
Add repositories to Polkadot-Network

### DIFF
--- a/migrations/2025-08-29T235959_mutations
+++ b/migrations/2025-08-29T235959_mutations
@@ -6,14 +6,12 @@ repadd 'Polkadot Network' https://github.com/ChainSafe/metamask-snap-polkadot/ #
 repadd 'Polkadot Network' https://github.com/tesseract-one/polkachat.rs #wallet
 repadd 'Polkadot Network' https://github.com/myriadsocial/myriad-node-parachain #parachain
 repadd 'Polkadot Network' https://github.com/NeoPower-Digital/tempora #developer-tool
-repadd 'Polkadot Network' https://github.com/perun-network/polkadot-wallet-grant #wallet
 repadd 'Polkadot Network' https://github.com/CoongCrafts/delightfuldot #developer-tool
 repadd 'Polkadot Network' https://github.com/rhysbalevicius/infimum #pallet
 repadd 'Polkadot Network' https://github.com/PolkaGate/polkaMask #wallet
 repadd 'Polkadot Network' https://github.com/MatteoPerona/ssal_commods #dApp
 repadd 'Polkadot Network' https://github.com/Deitos-Network/deitos-node #pallet
 repadd 'Polkadot Network' https://github.com/tokenguardio/dashboard-creator-client #analytics
-repadd 'Polkadot Network' https://github.com/element36-io/hyperfridge-r0 #compliance #zk
 repadd 'Polkadot Network' https://github.com/RegionX-Labs/CoretimeHub #dApp
 repadd 'Polkadot Network' https://github.com/farcloud-labs/subsmt/ #ink!
 repadd 'Polkadot Network' https://github.com/mlabs-haskell/TuxedoDapp #dApp


### PR DESCRIPTION
Adding a bunch of repositories that build on the Polkadot Network. This ranges from dApps to substrate pallets and even cryptography. 
Most of these have received a grant from the [web3 foundation](https://grants.web3.foundation/).

