### PR TITLE
SKALE Ecosystem Projects Update: Round 3

### DIFF
--- a/migrations/2025-09-12T180500_add_skale_network_updates
+++ b/migrations/2025-09-12T180500_add_skale_network_updates
@@ -22,8 +22,7 @@ ecocon "Skale Network" Tenamint
 
 -- Sub-Ecosystem developed on SKALE Network: GoArt
 ecoadd GoArt
-repadd GoArt https://github.com/GoArtMetaverse/smart-contracts/tree/GoArtMysteryBox #contracts
-repadd GoArt https://github.com/GoArtMetaverse/smart-contracts/tree/GoArtGoPack #contracts
+repadd GoArt https://github.com/GoArtMetaverse/smart-contracts
 ecocon "Skale Network" GoArt
 
 -- Sub-Ecosystem developed on SKALE Network: Reneverse


### PR DESCRIPTION
Addition of several new projects deployed on the SKALE Ecosystem. Some of this projects (the ones that are live) can be found on [DappRadar](https://dappradar.com/rankings?chains=skale-calypso%2Cskale-omnus%2Cskale-europa%2Cskale-nebula%2Cskale-exorde%2Cskale-strayshot%2Cskale-titan)