### PR TITLE
Add some Stellar repos

### DIFF
--- a/migrations/2025-09-26T075550_add_stellar_repos
+++ b/migrations/2025-09-26T075550_add_stellar_repos
@@ -1,0 +1,4 @@
+repadd Stellar https://github.com/ZencypherSolutions/semaphore-stellar-docs
+repadd Stellar https://github.com/Crypto-Jaguars/Revolutionary-Farmers
+repadd Stellar https://github.com/ZencypherSolutions/semaphore-stellar-boilerplate
+repadd Stellar https://github.com/Rub-a-Dab-Dub/whspr_stellar


### PR DESCRIPTION
This migration adds **4 Stellar repositories** under the Stellar ecosystem in the Electric Capital crypto-ecosystems taxonomy.

**Context:**
We’re collaborating with [OnlyDust.com](https://onlydust.com), a platform where open-source web3 projects are built by independent builders.
We’ve been working closely with Stellar for the past 12 months.

Happy to answer any questions!