### PR TITLE
Add noir_sepolia_demo project to the Noir Lang ecosystem

### DIFF
--- a/migrations/2025-10-02T231800_add-noir_sepolia_demo
+++ b/migrations/2025-10-02T231800_add-noir_sepolia_demo
@@ -1,0 +1,1 @@
+repadd "Noir Lang" https://github.com/cypriansakwa/noir_sepolia_demo #zkp  #zk-circuit #noir #aztec 


### PR DESCRIPTION
Adds noir_sepolia_demo project to the "Noir Lang" ecosystem. 

Repository: https://github.com/cypriansakwa/noir_sepolia_demo 

Tags: #zkp #zk-circuit #noir #aztec 

Data Source: Electric Capital Crypto Ecosystems 

If you're working in open source crypto, submit your repository here to be counted.