### PR TITLE
Add Namada Node Launcher repository to Anoma ecosystem

### DIFF
--- a/migrations/2025-10-02T150500_add_namada_wallet
+++ b/migrations/2025-10-02T150500_add_namada_wallet
@@ -1,0 +1,1 @@
+repadd Anoma https://github.com/anoma/namada-wallet #wallet #rust

--- a/migrations/2025-10-02T173000_add_warden_faucet
+++ b/migrations/2025-10-02T173000_add_warden_faucet
@@ -1,1 +1,0 @@
-repadd Warden https://github.com/warden-protocol/faucet #utility #go

--- a/migrations/2025-10-02T173000_add_warden_faucet
+++ b/migrations/2025-10-02T173000_add_warden_faucet
@@ -1,0 +1,1 @@
+repadd Warden https://github.com/warden-protocol/faucet #utility #go

--- a/migrations/2025-10-03T153000_add_namada_node_launcher
+++ b/migrations/2025-10-03T153000_add_namada_node_launcher
@@ -1,0 +1,1 @@
+repadd Anoma https://github.com/anoma/namada-node-launcher #infrastructure #rust


### PR DESCRIPTION
This PR adds the Namada Node Launcher repository under the Anoma ecosystem.

- Repository: https://github.com/anoma/namada-node-launcher
- Tags: infrastructure, rust
- Purpose: Provides tooling to easily launch and manage Namada nodes, simplifying validator and developer setup.
