### PR TITLE
Add Namada Faucet repository to Anoma ecosystem

### DIFF
--- a/migrations/2025-10-02T150500_add_namada_wallet
+++ b/migrations/2025-10-02T150500_add_namada_wallet
@@ -1,0 +1,1 @@
+repadd Anoma https://github.com/anoma/namada-wallet #wallet #rust

--- a/migrations/2025-10-02T173000_add_warden_faucet
+++ b/migrations/2025-10-02T173000_add_warden_faucet
@@ -1,1 +1,0 @@
-repadd Warden https://github.com/warden-protocol/faucet #utility #go

--- a/migrations/2025-10-02T173000_add_warden_faucet
+++ b/migrations/2025-10-02T173000_add_warden_faucet
@@ -1,0 +1,1 @@
+repadd Warden https://github.com/warden-protocol/faucet #utility #go

--- a/migrations/2025-10-03T160000_add_namada_faucet
+++ b/migrations/2025-10-03T160000_add_namada_faucet
@@ -1,0 +1,1 @@
+repadd Anoma https://github.com/anoma/namada-faucet #faucet #infrastructure


### PR DESCRIPTION
This PR adds the Namada Faucet repository under the Anoma ecosystem.

- Repository: https://github.com/anoma/namada-faucet
- Tags: faucet, infrastructure
- Purpose: Provides a faucet service to distribute test tokens for developers and users in the Namada ecosystem.
