### PR TITLE
Add Namada Workshop repository to Anoma ecosystem

### DIFF
--- a/migrations/2025-10-02T150500_add_namada_wallet
+++ b/migrations/2025-10-02T150500_add_namada_wallet
@@ -1,0 +1,1 @@
+repadd Anoma https://github.com/anoma/namada-wallet #wallet #rust

--- a/migrations/2025-10-02T173000_add_warden_faucet
+++ b/migrations/2025-10-02T173000_add_warden_faucet
@@ -1,1 +1,0 @@
-repadd Warden https://github.com/warden-protocol/faucet #utility #go

--- a/migrations/2025-10-02T173000_add_warden_faucet
+++ b/migrations/2025-10-02T173000_add_warden_faucet
@@ -1,0 +1,1 @@
+repadd Warden https://github.com/warden-protocol/faucet #utility #go

--- a/migrations/2025-10-03T163000_add_namada_workshop
+++ b/migrations/2025-10-03T163000_add_namada_workshop
@@ -1,0 +1,1 @@
+repadd Anoma https://github.com/anoma/namada-workshop #education #examples


### PR DESCRIPTION
This PR adds the Namada Workshop repository under the Anoma ecosystem.

- Repository: https://github.com/anoma/namada-workshop
- Tags: education, examples
- Purpose: Provides workshops and example projects to help developers and the community learn and build on Namada.
