### PR TITLE
Add algorandfoundation/algokit-cli to Algorand ecosystem

### DIFF
--- a/migrations/2025-10-02T150500_add_namada_wallet
+++ b/migrations/2025-10-02T150500_add_namada_wallet
@@ -1,0 +1,1 @@
+repadd Anoma https://github.com/anoma/namada-wallet #wallet #rust

--- a/migrations/2025-10-02T173000_add_warden_faucet
+++ b/migrations/2025-10-02T173000_add_warden_faucet
@@ -1,1 +1,0 @@
-repadd Warden https://github.com/warden-protocol/faucet #utility #go

--- a/migrations/2025-10-02T173000_add_warden_faucet
+++ b/migrations/2025-10-02T173000_add_warden_faucet
@@ -1,0 +1,1 @@
+repadd Warden https://github.com/warden-protocol/faucet #utility #go

--- a/migrations/2025-10-04T100100_add_algorand_algokit_cli
+++ b/migrations/2025-10-04T100100_add_algorand_algokit_cli
@@ -1,0 +1,1 @@
+repadd Algorand https://github.com/algorandfoundation/algokit-cli #developer-tool #cli


### PR DESCRIPTION
- Repository: https://github.com/algorandfoundation/algokit-cli
- Tags: developer-tool, cli
- Purpose: Official one-stop CLI for building on Algorand (AlgoKit).
