### PR TITLE
Add celo-org/developer-tooling to Celo ecosystem

### DIFF
--- a/migrations/2025-10-02T150500_add_namada_wallet
+++ b/migrations/2025-10-02T150500_add_namada_wallet
@@ -1,0 +1,1 @@
+repadd Anoma https://github.com/anoma/namada-wallet #wallet #rust

--- a/migrations/2025-10-02T173000_add_warden_faucet
+++ b/migrations/2025-10-02T173000_add_warden_faucet
@@ -1,1 +1,0 @@
-repadd Warden https://github.com/warden-protocol/faucet #utility #go

--- a/migrations/2025-10-02T173000_add_warden_faucet
+++ b/migrations/2025-10-02T173000_add_warden_faucet
@@ -1,0 +1,1 @@
+repadd Warden https://github.com/warden-protocol/faucet #utility #go

--- a/migrations/2025-10-05T101000_add_celo_developer_tooling
+++ b/migrations/2025-10-05T101000_add_celo_developer_tooling
@@ -1,0 +1,2 @@
+repadd Celo https://github.com/celo-org/developer-tooling #sdk #cli #typescript
+


### PR DESCRIPTION
- Repository: https://github.com/celo-org/developer-tooling
- Tags: sdk, cli, typescript
- Purpose: Official JS/TS developer tooling and CLIs for the Celo ecosystem.
