### PR TITLE
Add celo-org/docs to Celo ecosystem

### DIFF
--- a/migrations/2025-10-02T150500_add_namada_wallet
+++ b/migrations/2025-10-02T150500_add_namada_wallet
@@ -1,0 +1,1 @@
+repadd Anoma https://github.com/anoma/namada-wallet #wallet #rust

--- a/migrations/2025-10-02T173000_add_warden_faucet
+++ b/migrations/2025-10-02T173000_add_warden_faucet
@@ -1,1 +1,0 @@
-repadd Warden https://github.com/warden-protocol/faucet #utility #go

--- a/migrations/2025-10-02T173000_add_warden_faucet
+++ b/migrations/2025-10-02T173000_add_warden_faucet
@@ -1,0 +1,1 @@
+repadd Warden https://github.com/warden-protocol/faucet #utility #go

--- a/migrations/2025-10-05T101500_add_celo_docs
+++ b/migrations/2025-10-05T101500_add_celo_docs
@@ -1,0 +1,1 @@
+repadd Celo https://github.com/celo-org/docs #docs #mdx


### PR DESCRIPTION
- Repository: https://github.com/celo-org/docs
- Tags: docs, mdx
- Purpose: Source for the official Celo documentation (docs.celo.org).
