### PR TITLE
Add celo-org/celo-composer to Celo ecosystem

### DIFF
--- a/migrations/2025-10-02T150500_add_namada_wallet
+++ b/migrations/2025-10-02T150500_add_namada_wallet
@@ -1,0 +1,1 @@
+repadd Anoma https://github.com/anoma/namada-wallet #wallet #rust

--- a/migrations/2025-10-02T173000_add_warden_faucet
+++ b/migrations/2025-10-02T173000_add_warden_faucet
@@ -1,1 +1,0 @@
-repadd Warden https://github.com/warden-protocol/faucet #utility #go

--- a/migrations/2025-10-02T173000_add_warden_faucet
+++ b/migrations/2025-10-02T173000_add_warden_faucet
@@ -1,0 +1,1 @@
+repadd Warden https://github.com/warden-protocol/faucet #utility #go

--- a/migrations/2025-10-05T102000_add_celo_composer
+++ b/migrations/2025-10-05T102000_add_celo_composer
@@ -1,0 +1,1 @@
+repadd Celo https://github.com/celo-org/celo-composer #template #typescript #starter


### PR DESCRIPTION
- Repository: https://github.com/celo-org/celo-composer
- Tags: template, typescript, starter
- Purpose: Official starter/CLI for bootstrapping Celo dApps with a modern monorepo stack.
