### PR TITLE
Add celo-org/op-geth to Celo ecosystem

### DIFF
--- a/migrations/2025-10-02T150500_add_namada_wallet
+++ b/migrations/2025-10-02T150500_add_namada_wallet
@@ -1,0 +1,1 @@
+repadd Anoma https://github.com/anoma/namada-wallet #wallet #rust

--- a/migrations/2025-10-02T173000_add_warden_faucet
+++ b/migrations/2025-10-02T173000_add_warden_faucet
@@ -1,1 +1,0 @@
-repadd Warden https://github.com/warden-protocol/faucet #utility #go

--- a/migrations/2025-10-02T173000_add_warden_faucet
+++ b/migrations/2025-10-02T173000_add_warden_faucet
@@ -1,0 +1,1 @@
+repadd Warden https://github.com/warden-protocol/faucet #utility #go

--- a/migrations/2025-10-05T102500_add_celo_op_geth
+++ b/migrations/2025-10-05T102500_add_celo_op_geth
@@ -1,0 +1,1 @@
+repadd Celo https://github.com/celo-org/op-geth #node #execution


### PR DESCRIPTION
- Repository: https://github.com/celo-org/op-geth
- Tags: node, execution
- Purpose: Celo's execution client line aligned with the OP stack.
