### PR TITLE
Add noir-lang/noir to Noir ecosystem

### DIFF
--- a/migrations/2025-10-02T150500_add_namada_wallet
+++ b/migrations/2025-10-02T150500_add_namada_wallet
@@ -1,0 +1,1 @@
+repadd Anoma https://github.com/anoma/namada-wallet #wallet #rust

--- a/migrations/2025-10-02T173000_add_warden_faucet
+++ b/migrations/2025-10-02T173000_add_warden_faucet
@@ -1,1 +1,0 @@
-repadd Warden https://github.com/warden-protocol/faucet #utility #go

--- a/migrations/2025-10-02T173000_add_warden_faucet
+++ b/migrations/2025-10-02T173000_add_warden_faucet
@@ -1,0 +1,1 @@
+repadd Warden https://github.com/warden-protocol/faucet #utility #go

--- a/migrations/2025-10-05T104500_add_noir_lang_noir
+++ b/migrations/2025-10-05T104500_add_noir_lang_noir
@@ -1,0 +1,1 @@
+repadd Noir https://github.com/noir-lang/noir #language #rust


### PR DESCRIPTION
- Repository: https://github.com/noir-lang/noir
- Tags: language, rust
- Purpose: Core Noir language implementation.
