### PR TITLE
Add algokit-templates to Algorand ecosystem

### DIFF
--- a/migrations/2025-10-06T101500_add_algorand_algokit_templates
+++ b/migrations/2025-10-06T101500_add_algorand_algokit_templates
@@ -1,0 +1,1 @@
+repadd Algorand https://github.com/algorandfoundation/algokit-templates #template #starter


### PR DESCRIPTION
- Repository: https://github.com/algorandfoundation/algokit-templates
- Tags: template, starter
- Purpose: Official templates powering AlgoKit init flows.
