### PR TITLE
Add algokit-subscriber-py to Algorand ecosystem

### DIFF
--- a/migrations/2025-10-06T101800_add_algorand_algokit_subscriber_py
+++ b/migrations/2025-10-06T101800_add_algorand_algokit_subscriber_py
@@ -1,0 +1,1 @@
+repadd Algorand https://github.com/algorandfoundation/algokit-subscriber-py #events #python


### PR DESCRIPTION
- Repository: https://github.com/algorandfoundation/algokit-subscriber-py
- Tags: events, python
- Purpose: Python subscriber for Algorand event streams.
