### PR TITLE
Add algokit-example-gallery to Algorand ecosystem

### DIFF
--- a/migrations/2025-10-06T102100_add_algorand_algokit_example_gallery
+++ b/migrations/2025-10-06T102100_add_algorand_algokit_example_gallery
@@ -1,0 +1,1 @@
+repadd Algorand https://github.com/algorandfoundation/algokit-example-gallery #examples #algokit


### PR DESCRIPTION
- Repository: https://github.com/algorandfoundation/algokit-example-gallery
- Tags: examples, algokit
- Purpose: Gallery of ready-to-run AlgoKit examples.
