### PR TITLE
Add py-algorand-sdk to Algorand ecosystem

### DIFF
--- a/migrations/2025-10-06T102400_add_algorand_py_sdk
+++ b/migrations/2025-10-06T102400_add_algorand_py_sdk
@@ -1,0 +1,1 @@
+repadd Algorand https://github.com/algorand/py-algorand-sdk #sdk #python


### PR DESCRIPTION
- Repository: https://github.com/algorand/py-algorand-sdk
- Tags: sdk, python
- Purpose: Official Python SDK for Algorand.
