### PR TITLE
Add js-algorand-sdk to Algorand ecosystem

### DIFF
--- a/migrations/2025-10-06T102700_add_algorand_js_sdk
+++ b/migrations/2025-10-06T102700_add_algorand_js_sdk
@@ -1,0 +1,1 @@
+repadd Algorand https://github.com/algorand/js-algorand-sdk #sdk #javascript


### PR DESCRIPTION
- Repository: https://github.com/algorand/js-algorand-sdk
- Tags: sdk, javascript
- Purpose: Official JavaScript SDK for Algorand.
