### PR TITLE
Add zk-lessons-noir-psi-onchain project to the Noir Lang ecosystem

### DIFF
--- a/migrations/2025-10-07T221800_add-zk-lessons-noir-psi-onchain
+++ b/migrations/2025-10-07T221800_add-zk-lessons-noir-psi-onchain
@@ -1,0 +1,1 @@
+repadd "Noir Lang" https://github.com/cypriansakwa/zk-lessons-noir-psi-onchain #zkp #zk-circuit #noir #aztec #psi


### PR DESCRIPTION
Adds zk-lessons-noir-psi-onchain project to the "Noir Lang" ecosystem. 
	
Repository: https://github.com/cypriansakwa/zk-lessons-noir-psi-onchain
Tags: #zkp #zk-circuit #noir #aztec #psi 
	
Data Source: Electric Capital Crypto Ecosystems 
	
If you're working in open source crypto, submit your repository here to be counted. 