### PR TITLE
Add RunningNad (Farcaster miniapp / Frame)

### DIFF
--- a/migrations/runningnad.toml
+++ b/migrations/runningnad.toml
@@ -1,0 +1,1 @@
+repadd Social https://github.com/nosrb26/runningnad #dapp #social #frame


### PR DESCRIPTION
- Project: RunningNad – Farcaster miniapp (Frame)
- Repo: https://github.com/nosrb26/runningnad
- Live: https://runningnad.vercel.app/game
- License: MIT
- Topics: farcaster, frame, dapp, web3, crypto, nextjs, vercel, game
- Category tags: #dapp #social #frame