### PR TITLE
Add Namada Indexer Service to Anoma ecosystem

### DIFF
--- a/migrations/2025-10-07T161500_add_namada_indexer_service
+++ b/migrations/2025-10-07T161500_add_namada_indexer_service
@@ -1,1 +1,8 @@
-repadd Anoma https://github.com/anoma/namada-indexer-service #indexer #graphql #rust
+repadd Anoma https://github.com/anoma/namada #core #protocol #rust
+repadd Anoma https://github.com/anoma/namada-indexer #indexer #graphql #rust
+repadd Anoma https://github.com/anoma/namada-docs #docs #markdown #anoma
+repadd Anoma https://github.com/anoma/namada-wallet #wallet #gui #typescript
+repadd Anoma https://github.com/anoma/namada-shielded-exp #zkp #privacy #research
+repadd Anoma https://github.com/anoma/namada-rust-utils #rust #tools #library #anoma
+repadd Anoma https://github.com/anoma/namada-js-sdk #sdk #typescript #anoma
+repadd Anoma https://github.com/anoma/namada-data-visualizer #visualization #dashboard #anoma


### PR DESCRIPTION
- Repository: https://github.com/anoma/namada-indexer-service
- Tags: indexer, graphql, rust
- Purpose: Adds reference to the Namada Indexer Service that provides GraphQL-based access to on-chain data.
