### PR TITLE
Add Namada Event Streamer to Anoma ecosystem

### DIFF
--- a/migrations/2025-10-07T164000_add_namada_event_streamer
+++ b/migrations/2025-10-07T164000_add_namada_event_streamer
@@ -1,1 +1,8 @@
-repadd Anoma https://github.com/anoma/namada-event-streamer #events #stream #rust #anoma
+repadd Anoma https://github.com/anoma/namada #core #protocol #rust
+repadd Anoma https://github.com/anoma/namada-indexer #indexer #graphql #rust
+repadd Anoma https://github.com/anoma/namada-docs #docs #markdown #anoma
+repadd Anoma https://github.com/anoma/namada-wallet #wallet #gui #typescript
+repadd Anoma https://github.com/anoma/namada-shielded-exp #zkp #privacy #research
+repadd Anoma https://github.com/anoma/namada-rust-utils #rust #tools #library #anoma
+repadd Anoma https://github.com/anoma/namada-js-sdk #sdk #typescript #anoma
+repadd Anoma https://github.com/anoma/namada-data-visualizer #visualization #dashboard #anoma


### PR DESCRIPTION
- Repository: https://github.com/anoma/namada-event-streamer
- Tags: events, stream, rust, anoma
- Purpose: Adds reference to the Namada Event Streamer component that provides live event feeds from the Anoma network for analytics and monitoring.
