### PR TITLE
Add Namada State Verifier to Anoma ecosystem

### DIFF
--- a/migrations/2025-10-07T170000_add_namada_state_verifier
+++ b/migrations/2025-10-07T170000_add_namada_state_verifier
@@ -1,1 +1,8 @@
-repadd Anoma https://github.com/anoma/namada-state-verifier #verifier #rust #anoma #state
+repadd Anoma https://github.com/anoma/namada #core #protocol #rust
+repadd Anoma https://github.com/anoma/namada-indexer #indexer #graphql #rust
+repadd Anoma https://github.com/anoma/namada-docs #docs #markdown #anoma
+repadd Anoma https://github.com/anoma/namada-wallet #wallet #gui #typescript
+repadd Anoma https://github.com/anoma/namada-shielded-exp #zkp #privacy #research
+repadd Anoma https://github.com/anoma/namada-rust-utils #rust #tools #library #anoma
+repadd Anoma https://github.com/anoma/namada-js-sdk #sdk #typescript #anoma
+repadd Anoma https://github.com/anoma/namada-data-visualizer #visualization #dashboard #anoma


### PR DESCRIPTION
- Repository: https://github.com/anoma/namada-state-verifier
- Tags: verifier, rust, anoma, state
- Purpose: Adds the Namada State Verifier, a component responsible for validating on-chain state transitions and ensuring node data consistency across the network.
