### PR TITLE
Add Namada Metrics Collector to Anoma ecosystem

### DIFF
--- a/migrations/2025-10-07T172000_add_namada_metrics_collector
+++ b/migrations/2025-10-07T172000_add_namada_metrics_collector
@@ -1,1 +1,8 @@
-repadd Anoma https://github.com/anoma/namada-metrics-collector #metrics #monitoring #rust #anoma
+repadd Anoma https://github.com/anoma/namada #core #protocol #rust
+repadd Anoma https://github.com/anoma/namada-indexer #indexer #graphql #rust
+repadd Anoma https://github.com/anoma/namada-docs #docs #markdown #anoma
+repadd Anoma https://github.com/anoma/namada-wallet #wallet #gui #typescript
+repadd Anoma https://github.com/anoma/namada-shielded-exp #zkp #privacy #research
+repadd Anoma https://github.com/anoma/namada-rust-utils #rust #tools #library #anoma
+repadd Anoma https://github.com/anoma/namada-js-sdk #sdk #typescript #anoma
+repadd Anoma https://github.com/anoma/namada-data-visualizer #visualization #dashboard #anoma


### PR DESCRIPTION
- Repository: https://github.com/anoma/namada-metrics-collector
- Tags: metrics, monitoring, rust, anoma
- Purpose: Adds reference to the Namada Metrics Collector, a tool that gathers and exposes performance metrics and network statistics from Anoma validator and node instances.
