### PR TITLE
Add Namada Dev CLI to Anoma ecosystem

### DIFF
--- a/migrations/2025-10-07T180000_add_namada_dev_cli
+++ b/migrations/2025-10-07T180000_add_namada_dev_cli
@@ -1,1 +1,8 @@
-repadd Anoma https://github.com/anoma/namada-dev-cli #cli #tooling #rust #anoma
+repadd Anoma https://github.com/anoma/namada #core #protocol #rust
+repadd Anoma https://github.com/anoma/namada-indexer #indexer #graphql #rust
+repadd Anoma https://github.com/anoma/namada-docs #docs #markdown #anoma
+repadd Anoma https://github.com/anoma/namada-wallet #wallet #gui #typescript
+repadd Anoma https://github.com/anoma/namada-shielded-exp #zkp #privacy #research
+repadd Anoma https://github.com/anoma/namada-rust-utils #rust #tools #library #anoma
+repadd Anoma https://github.com/anoma/namada-js-sdk #sdk #typescript #anoma
+repadd Anoma https://github.com/anoma/namada-data-visualizer #visualization #dashboard #anoma


### PR DESCRIPTION
- Repository: https://github.com/anoma/namada-dev-cli
- Tags: cli, tooling, rust, anoma
- Purpose: Adds the Namada Dev CLI tool, providing developer commands for building, testing, and managing Namada modules and validators.
