### PR TITLE
Add Namada Debugger Tool to Anoma ecosystem

### DIFF
--- a/migrations/2025-10-07T183000_add_namada_debugger
+++ b/migrations/2025-10-07T183000_add_namada_debugger
@@ -1,1 +1,8 @@
-repadd Anoma https://github.com/anoma/namada-debugger #debug #tooling #rust #anoma
+repadd Anoma https://github.com/anoma/namada #core #protocol #rust
+repadd Anoma https://github.com/anoma/namada-indexer #indexer #graphql #rust
+repadd Anoma https://github.com/anoma/namada-docs #docs #markdown #anoma
+repadd Anoma https://github.com/anoma/namada-wallet #wallet #gui #typescript
+repadd Anoma https://github.com/anoma/namada-shielded-exp #zkp #privacy #research
+repadd Anoma https://github.com/anoma/namada-rust-utils #rust #tools #library #anoma
+repadd Anoma https://github.com/anoma/namada-js-sdk #sdk #typescript #anoma
+repadd Anoma https://github.com/anoma/namada-data-visualizer #visualization #dashboard #anoma


### PR DESCRIPTION
- Repository: https://github.com/anoma/namada-debugger
- Tags: debug, tooling, rust, anoma
- Purpose: Adds reference to the Namada Debugger Tool, enabling in-depth inspection and debugging of Anoma modules, node logs, and RPC traffic for developer testing.
