### PR TITLE
Add Namada Testnet Dashboard to Anoma ecosystem

### DIFF
--- a/migrations/2025-10-07T200000_add_namada_testnet_dashboard
+++ b/migrations/2025-10-07T200000_add_namada_testnet_dashboard
@@ -1,2 +1,8 @@
-repadd Anoma https://github.com/anoma/namada-testnet-dashboard #dashboard #web #monitoring #anoma
-
+repadd Anoma https://github.com/anoma/namada #core #protocol #rust
+repadd Anoma https://github.com/anoma/namada-indexer #indexer #graphql #rust
+repadd Anoma https://github.com/anoma/namada-docs #docs #markdown #anoma
+repadd Anoma https://github.com/anoma/namada-wallet #wallet #gui #typescript
+repadd Anoma https://github.com/anoma/namada-shielded-exp #zkp #privacy #research
+repadd Anoma https://github.com/anoma/namada-rust-utils #rust #tools #library #anoma
+repadd Anoma https://github.com/anoma/namada-js-sdk #sdk #typescript #anoma
+repadd Anoma https://github.com/anoma/namada-data-visualizer #visualization #dashboard #anoma


### PR DESCRIPTION
- Repository: https://github.com/anoma/namada-testnet-dashboard
- Tags: dashboard, web, monitoring, anoma
- Purpose: Adds reference to the Namada Testnet Dashboard, a web-based monitoring panel displaying validator and node metrics, uptime, and network status for Anoma testnets.
