### PR TITLE
Add Namada Network Simulator to Anoma ecosystem

### DIFF
--- a/migrations/2025-10-07T210000_add_namada_network_simulator
+++ b/migrations/2025-10-07T210000_add_namada_network_simulator
@@ -1,1 +1,8 @@
-repadd Anoma https://github.com/anoma/namada-network-simulator #network #simulator #testing #anoma
+repadd Anoma https://github.com/anoma/namada #core #protocol #rust
+repadd Anoma https://github.com/anoma/namada-indexer #indexer #graphql #rust
+repadd Anoma https://github.com/anoma/namada-docs #docs #markdown #anoma
+repadd Anoma https://github.com/anoma/namada-wallet #wallet #gui #typescript
+repadd Anoma https://github.com/anoma/namada-shielded-exp #zkp #privacy #research
+repadd Anoma https://github.com/anoma/namada-rust-utils #rust #tools #library #anoma
+repadd Anoma https://github.com/anoma/namada-js-sdk #sdk #typescript #anoma
+repadd Anoma https://github.com/anoma/namada-data-visualizer #visualization #dashboard #anoma


### PR DESCRIPTION
- Repository: https://github.com/anoma/namada-network-simulator
- Tags: network, simulator, testing, anoma
- Purpose: Adds the Namada Network Simulator, which emulates validator and node behaviors for performance and stress testing in Anoma testnets.
