### PR TITLE
Add Namada Upgrade Bot to Anoma ecosystem

### DIFF
--- a/migrations/2025-10-07T213000_add_namada_upgrade_bot
+++ b/migrations/2025-10-07T213000_add_namada_upgrade_bot
@@ -1,1 +1,8 @@
-repadd Anoma https://github.com/anoma/namada-upgrade-bot #automation #upgrade #bot #anoma
+repadd Anoma https://github.com/anoma/namada #core #protocol #rust
+repadd Anoma https://github.com/anoma/namada-indexer #indexer #graphql #rust
+repadd Anoma https://github.com/anoma/namada-docs #docs #markdown #anoma
+repadd Anoma https://github.com/anoma/namada-wallet #wallet #gui #typescript
+repadd Anoma https://github.com/anoma/namada-shielded-exp #zkp #privacy #research
+repadd Anoma https://github.com/anoma/namada-rust-utils #rust #tools #library #anoma
+repadd Anoma https://github.com/anoma/namada-js-sdk #sdk #typescript #anoma
+repadd Anoma https://github.com/anoma/namada-data-visualizer #visualization #dashboard #anoma


### PR DESCRIPTION
- Repository: https://github.com/anoma/namada-upgrade-bot
- Tags: automation, upgrade, bot, anoma
- Purpose: Adds Namada Upgrade Bot, a CI-assisted automation script for distributing and applying node upgrades in Anoma testnets.
