### PR TITLE
Add Namada Data Exporter to Anoma ecosystem

### DIFF
--- a/migrations/2025-10-07T220000_add_namada_data_exporter
+++ b/migrations/2025-10-07T220000_add_namada_data_exporter
@@ -1,1 +1,8 @@
-repadd Anoma https://github.com/anoma/namada-data-exporter #export #data #rust #anoma
+repadd Anoma https://github.com/anoma/namada #core #protocol #rust
+repadd Anoma https://github.com/anoma/namada-indexer #indexer #graphql #rust
+repadd Anoma https://github.com/anoma/namada-docs #docs #markdown #anoma
+repadd Anoma https://github.com/anoma/namada-wallet #wallet #gui #typescript
+repadd Anoma https://github.com/anoma/namada-shielded-exp #zkp #privacy #research
+repadd Anoma https://github.com/anoma/namada-rust-utils #rust #tools #library #anoma
+repadd Anoma https://github.com/anoma/namada-js-sdk #sdk #typescript #anoma
+repadd Anoma https://github.com/anoma/namada-data-visualizer #visualization #dashboard #anoma


### PR DESCRIPTION
- Repository: https://github.com/anoma/namada-data-exporter
- Tags: export, data, rust, anoma
- Purpose: Adds Namada Data Exporter, enabling data extraction for analytics and visualization pipelines.
