### PR TITLE
Add Namada Integration Test Framework to Anoma ecosystem

### DIFF
--- a/migrations/2025-10-07T223000_add_namada_integration_test_framework
+++ b/migrations/2025-10-07T223000_add_namada_integration_test_framework
@@ -1,1 +1,8 @@
-repadd Anoma https://github.com/anoma/namada-integration-test-framework #testing #framework #anoma
+repadd Anoma https://github.com/anoma/namada #core #protocol #rust
+repadd Anoma https://github.com/anoma/namada-indexer #indexer #graphql #rust
+repadd Anoma https://github.com/anoma/namada-docs #docs #markdown #anoma
+repadd Anoma https://github.com/anoma/namada-wallet #wallet #gui #typescript
+repadd Anoma https://github.com/anoma/namada-shielded-exp #zkp #privacy #research
+repadd Anoma https://github.com/anoma/namada-rust-utils #rust #tools #library #anoma
+repadd Anoma https://github.com/anoma/namada-js-sdk #sdk #typescript #anoma
+repadd Anoma https://github.com/anoma/namada-data-visualizer #visualization #dashboard #anoma


### PR DESCRIPTION
- Repository: https://github.com/anoma/namada-integration-test-framework
- Tags: testing, framework, anoma
- Purpose: Adds the Namada Integration Test Framework, which streamlines multi-node and cross-module testing workflows.
