### PR TITLE
Add zk-verifier-foundry-sepolia circuit to the Noir Lang ecosystem

### DIFF
--- a/migrations/2025-10-13T072600_add-zk-verifier-foundry-sepolia
+++ b/migrations/2025-10-13T072600_add-zk-verifier-foundry-sepolia
@@ -1,1 +1,1 @@
-repadd "Noir Lang" https://github.com/cypriansakwa/zk-verifier-foundry-sepolia #zkp #zk-circuit #noir #aztec #ethereum #sopalia
+repadd "Noir Lang" https://github.com/cypriansakwa/noir-zk-verifier-foundry-sepolia #zkp #zk-circuit #noir #aztec #ethereum #sopalia


### PR DESCRIPTION
Adds noir-zk-verifier-foundry-sepolia circuit to the "Noir Lang" ecosystem.
	
Repository: https://github.com/cypriansakwa/noir-zk-verifier-foundry-sepolia 
Tags: #zkp #zk-circuit #noir #aztec #ethereum #sopalia 
	
Data Source: Electric Capital Crypto Ecosystems 

If you're working in open source crypto, submit your repository here to be counted.


	