### PR TITLE
Anoma: add public docs/spec repositories (round 2)

### DIFF
--- a/migrations/2025-10-13T173000_add_anoma_docs_round2.sql
+++ b/migrations/2025-10-13T173000_add_anoma_docs_round2.sql
@@ -1,0 +1,8 @@
+-- 2025-10-13T17:30:00Z add_anoma_docs_round2
+-- Public documentation/spec repositories under the official `anoma` org
+
+repadd Anoma https://github.com/anoma/nspec                   #spec #docs
+repadd Anoma https://github.com/anoma/whitepaper              #whitepaper #docs
+repadd Anoma https://github.com/anoma/specs.anoma.net         #docs #website
+repadd Anoma https://github.com/anoma/developer-docs          #docs #devrel
+repadd Anoma https://github.com/anoma/anoma-beta-documentation #docs #beta


### PR DESCRIPTION
Adds verified public documentation/spec repos under the official anoma org.
Scoped to docs/spec only for quick review.
Excluded repos that are already linked (e.g., anoma/anoma, anoma/namada, anoma/namada-genesis).
Tags follow existing taxonomy (#docs, #spec, #website, #devrel, #beta).
