### PR TITLE
Anoma: anoma-apps, evm-protocol-adapter, anoma-local-domain (Round 3)

### DIFF
--- a/migrations/2025-10-17T1702_anoma_round3_apps_infra.txt
+++ b/migrations/2025-10-17T1702_anoma_round3_apps_infra.txt
@@ -1,0 +1,3 @@
+repadd Anoma https://github.com/anoma/anoma-apps           #examples #devrel
+repadd Anoma https://github.com/anoma/evm-protocol-adapter #evm #bridge #solidity
+repadd Anoma https://github.com/anoma/anoma-local-domain   #infra #tooling


### PR DESCRIPTION
This migration adds three official repositories under the Anoma org:

- anoma-apps (#examples #devrel)
- evm-protocol-adapter (#evm #bridge #solidity)
- anoma-local-domain (#infra #tooling)

All are public and not currently listed in the registry. Kept the change small and focused to ease review. Cross-checked against the author's 17 previously merged PRs to avoid duplicates.
