### PR TITLE
Anoma: juvix + juvix-quickcheck (Round 3)

### DIFF
--- a/migrations/2025-10-17T1710_anoma_round1_lang.txt
+++ b/migrations/2025-10-17T1710_anoma_round1_lang.txt
@@ -1,0 +1,2 @@
+repadd Anoma https://github.com/anoma/juvix            #sdk #compiler #language
+repadd Anoma https://github.com/anoma/juvix-quickcheck #dev-tool #testing


### PR DESCRIPTION
This migration adds two official repositories under the Anoma org:

- juvix (#sdk #compiler #language)
- juvix-quickcheck (#dev-tool #testing)

Both are public and currently not listed in the registry. Kept the change small and focused to ease review. Cross-checked against the author's 17 previously merged PRs to avoid duplicates.
