### PR TITLE
Anoma: geb + goose-lean (Round 3)

### DIFF
--- a/migrations/2025-10-17T1713_anoma_round3_theory.txt
+++ b/migrations/2025-10-17T1713_anoma_round3_theory.txt
@@ -1,0 +1,2 @@
+repadd Anoma https://github.com/anoma/geb        #research #docs
+repadd Anoma https://github.com/anoma/goose-lean #spec #theory


### PR DESCRIPTION
This migration adds two official repositories under the Anoma org:

- geb (#research #docs)
- goose-lean (#spec #theory)

Both are public and currently not listed in the registry. Small, focused change for easier review. Cross-checked against the author's 17 previously merged PRs to avoid duplicates.
