### PR TITLE
Anoma: arm-risc0 + Simple-Transfer-Example (Round 4)

### DIFF
--- a/migrations/2025-10-17T1722_anoma_round4_arm_examples.txt
+++ b/migrations/2025-10-17T1722_anoma_round4_arm_examples.txt
@@ -1,0 +1,2 @@
+repadd Anoma https://github.com/anoma/arm-risc0              #zkvm #arm #rust
+repadd Anoma https://github.com/anoma/Simple-Transfer-Example #examples #app


### PR DESCRIPTION
This migration adds two official repositories under the Anoma org:

- arm-risc0 (#zkvm #arm #rust)
- Simple-Transfer-Example (#examples #app)

Both are public, active, and not listed yet. Small, focused change for easier review.