### PR TITLE
Anoma: anoma-applib + juvix-stdlib (Round 5)

### DIFF
--- a/migrations/2025-10-17T1726_anoma_round5_sdk_lang.txt
+++ b/migrations/2025-10-17T1726_anoma_round5_sdk_lang.txt
@@ -1,0 +1,2 @@
+repadd Anoma https://github.com/anoma/anoma-applib  #sdk #library
+repadd Anoma https://github.com/anoma/juvix-stdlib  #language #stdlib


### PR DESCRIPTION
This migration adds two official repositories under the Anoma org:

- anoma-applib (#sdk #library)
- juvix-stdlib (#language #stdlib)

Both are public and active. Kept the change small and focused; no duplicates with previous PRs.
