### PR TITLE
Privacy: MASP MPC tools — anoma/masp-mpc, anoma/verify-beacon, namada-net/masp (Round 6)

### DIFF
--- a/migrations/2025-10-17T1730_privacy_round6_masp_mpc.txt
+++ b/migrations/2025-10-17T1730_privacy_round6_masp_mpc.txt
@@ -1,0 +1,3 @@
+repadd Anoma    https://github.com/anoma/masp-mpc      #mpc #privacy #rust
+repadd Anoma    https://github.com/anoma/verify-beacon #mpc #beacon #sha256
+repadd Namada   https://github.com/namada-net/masp     #masp #privacy #rust


### PR DESCRIPTION
This migration adds three public repositories contributing to the MASP/MPC toolchain:

- anoma/masp-mpc (#mpc #privacy #rust)
- anoma/verify-beacon (#mpc #beacon #sha256)
- namada-net/masp (#masp #privacy #rust)

All are public and currently not listed. Kept the change focused; cross-checked with prior merged PRs to avoid duplicates.
