### PR TITLE
Anoma: arm-risc0 + Simple-Transfer-Example (Round 7)

### DIFF
--- a/migrations/2025-10-20T1626_anoma_round7_arm_risc0_simple_transfer.txt
+++ b/migrations/2025-10-20T1626_anoma_round7_arm_risc0_simple_transfer.txt
@@ -1,0 +1,2 @@
+repadd Anoma https://github.com/anoma/arm-risc0              #zkvm #arm #rust
+repadd Anoma https://github.com/anoma/Simple-Transfer-Example #examples #app


### PR DESCRIPTION
This migration adds two official repositories under the Anoma org:

- anoma/arm-risc0 (#zkvm #arm #rust)
- anoma/Simple-Transfer-Example (#examples #app)

Both repositories are public, active, and not currently listed in the registry. This is a small, focused change intended to ease review. Cross-checked against previously merged PRs to avoid duplicates.
