### PR TITLE
Anoma: anoma-applib + juvix-stdlib (Round 8)

### DIFF
--- a/migrations/2025-10-20T1627_anoma_round8_applib_juvix_stdlib.txt
+++ b/migrations/2025-10-20T1627_anoma_round8_applib_juvix_stdlib.txt
@@ -1,0 +1,2 @@
+repadd Anoma https://github.com/anoma/anoma-applib  #sdk #library
+repadd Anoma https://github.com/anoma/juvix-stdlib  #language #stdlib


### PR DESCRIPTION
This migration adds two official repositories under the Anoma org:

- anoma/anoma-applib (#sdk #library)
- anoma/juvix-stdlib (#language #stdlib)

Both repositories are public, actively maintained, and not currently listed in the registry. Kept intentionally small to facilitate quick review. Verified no duplicates with prior merged PRs.
