### PR TITLE
Privacy: MASP MPC tools — anoma/masp-mpc, anoma/verify-beacon, namada-net/masp (Round 9)

### DIFF
--- a/migrations/2025-10-20T1627_privacy_round9_masp_mpc.txt
+++ b/migrations/2025-10-20T1627_privacy_round9_masp_mpc.txt
@@ -1,3 +1,1 @@
-repadd Anoma    https://github.com/anoma/masp-mpc      #mpc #privacy #rust
-repadd Anoma    https://github.com/anoma/verify-beacon #mpc #beacon #sha256
 repadd Namada   https://github.com/namada-net/masp     #masp #privacy #rust


### PR DESCRIPTION
This migration adds three public repositories contributing to the MASP/MPC toolchain:

- anoma/masp-mpc (#mpc #privacy #rust)
- anoma/verify-beacon (#mpc #beacon #sha256)
- namada-net/masp (#masp #privacy #rust)

All repositories are public and currently not listed in the registry. This focused change is intended to add privacy tooling in a review-friendly way. Cross-checked with previous merged PRs to avoid duplicates.
