### PR TITLE
Add base-sepolia-deploy-setup circuit to the Noir Lang ecosystem

### DIFF
--- a/migrations/2025-10-24T192200_add-base-sepolia-deploy-setup
+++ b/migrations/2025-10-24T192200_add-base-sepolia-deploy-setup
@@ -1,0 +1,1 @@
+repadd "Noir Lang" https://github.com/cypriansakwa/base-sepolia-deploy-setup #zkp #zk-circuit #noir #aztec #base


### PR DESCRIPTION
Adds base-sepolia-deploy-setup circuit to the "Noir Lang" ecosystem.
	
Repository: https://github.com/cypriansakwa/base-sepolia-deploy-setup
Tags: #zkp #zk-circuit #noir #aztec #base 
	
Data Source: Electric Capital Crypto Ecosystems
	
If you're working in open source crypto, submit your repository here to be counted.