### PR TITLE
fix invalid algorand migration location

### DIFF
--- a/migrations/2025-10-21T235959_algorand_updates
+++ b/migrations/2025-10-21T235959_algorand_updates
@@ -1,1 +1,1 @@
-repadd Algorand https://github.com/blockedge-tech/collabchain
+repadd Algorand https://github.com/michaeltchuangllc/algokit-walletsdk-kmp

--- a/migrations/migrations/2025-10-21T235959_algorand_updates
+++ b/migrations/migrations/2025-10-21T235959_algorand_updates
@@ -1,1 +1,0 @@
-repadd Algorand https://github.com/michaeltchuangllc/algokit-walletsdk-kmp


### PR DESCRIPTION
Invalid migration path introduced in https://github.com/electric-capital/crypto-ecosystems/pull/2322