### PR TITLE
Add Scaffold-ETH ecosystem repositories (4,442 repos built with Scaffold-ETH 2)

### DIFF
--- a/migrations/2025-10-29T100813_add_scaffold_eth_ecosystem_repos
+++ b/migrations/2025-10-29T100813_add_scaffold_eth_ecosystem_repos
@@ -1,10 +1,7 @@
 -- Add Scaffold-ETH ecosystem repositories
 -- This migration adds 4445 repositories that are builds created with Scaffold-ETH 2
--- Includes official BuidlGuidl/scaffold-eth organization repos and community builds
+-- Includes official BuidlGuidl organization repos and community builds
 
-repadd Scaffold-ETH https://github.com/scaffold-eth/SablierV2_starterKit
-repadd Scaffold-ETH https://github.com/scaffold-eth/scaffoldeth.io
-repadd Scaffold-ETH https://github.com/scaffold-eth/Scaffold-ETH-DeFi-Challenges
 repadd Scaffold-ETH https://github.com/BuidlGuidl/abi.ninja
 repadd Scaffold-ETH https://github.com/buidlguidl/address-vision
 repadd Scaffold-ETH https://github.com/buidlguidl/address-vision-port


### PR DESCRIPTION
Adds 4,442 Scaffold-ETH 2 builds across BuidlGuidl and community repos.

Quality check as October 28, 2025:
- Public and accessible repos
- Verified Scaffold-ETH 2 usage
- Deduplicated
- Excluded repos already in EC

Thanks! Happy to tweak if needed.