### PR TITLE
feat: Add FiniteFields repo

### DIFF
--- a/migrations/2025-11-01T103000_add_repo_fields
+++ b/migrations/2025-11-01T103000_add_repo_fields
@@ -1,1 +1,1 @@
-repadd FiniteFields https://github.com/nougzarm/corps_finis
+repadd Core https://github.com/nougzarm/corps_finis


### PR DESCRIPTION
Hello Electric Capital team,

This PR adds our repository, `corps_finis`.

**Repository URL:**
`https://github.com/nougzarm/corps_finis`

**Context:**
This repository contains `corps_finis`, a foundational C library that provides tools for finite field arithmetic.