### PR TITLE
feat: Add sigma-rs/sigma-proofs to `Zero Knowledge Cryptography`

### DIFF
--- a/migrations/2025-11-01T103000_add_repo_fields
+++ b/migrations/2025-11-01T103000_add_repo_fields
@@ -1,1 +1,0 @@
-repadd Core https://github.com/nougzarm/corps_finis


### PR DESCRIPTION
Hello Electric Capital team,

This PR adds the `sigma-rs/sigma-proofs` repository to the `Zero Knowledge Cryptography` ecosystem.

**Repository URL:**
`https://github.com/sigma-rs/sigma-proofs`

**Context:**
This repository is a Rust implementation of Sigma protocols, a class of zero-knowledge proofs.

It provides foundational cryptographic tooling for privacy-preserving applications (such as confidential transactions or signatures) relevant to the `Zero Knowledge Cryptography` ecosystem.