### PR TITLE
Adding Community Repos from Arbitrum Initiatives

### DIFF
--- a/migrations/2025-11-04T150501_arbitrum_repos
+++ b/migrations/2025-11-04T150501_arbitrum_repos
@@ -10,7 +10,6 @@ repadd Arbitrum https://github.com/AmaanSayyad/Apt-Casino-Arbitrum
 repadd Arbitrum https://github.com/AndreaDiazCorreia/MintPraMim
 repadd Arbitrum https://github.com/ArbitrumFoundation/stylus-workshop-gol
 repadd Arbitrum https://github.com/AvinashNayak27/credstreak
-repadd Arbitrum https://github.com/Ayushsingla1/gridlock
 repadd Arbitrum https://github.com/Bagtz/ita-mc
 repadd Arbitrum https://github.com/DCA-MiniApp/dca-vibekit-agent
 repadd Arbitrum https://github.com/DEVANSH-GAJJAR/erc20_interactor
@@ -26,22 +25,14 @@ repadd Arbitrum https://github.com/NileshRP010/fylaro-finternet-finance
 repadd Arbitrum https://github.com/OoviyaManickam/OnlyFarmers
 repadd Arbitrum https://github.com/PhatDot1/DeltaLink_Submission_Repo
 repadd Arbitrum https://github.com/Rithvik-krishna/ArbiRupee
-repadd Arbitrum https://github.com/Rounak0407/TreeView
 repadd Arbitrum https://github.com/Sahid-m/xarbi-full
-repadd Arbitrum https://github.com/SharmARohitt/metaloot
-repadd Arbitrum https://github.com/SharmARohitt/spend2grow
 repadd Arbitrum https://github.com/Superior212/soma
 repadd Arbitrum https://github.com/Tulio-CS/Hackaton-ModularCripto
 repadd Arbitrum https://github.com/Vipul-045/StreamPay-arbitrum
-repadd Arbitrum https://github.com/Web3-baddie/Meta-nexus
 repadd Arbitrum https://github.com/abxglia/gmx-safe-sdk
-repadd Arbitrum https://github.com/ayush035/final
 repadd Arbitrum https://github.com/denysenkod/encode_october_hack
 repadd Arbitrum https://github.com/devsxtra/Alloc8-Hedge-fund
-repadd Arbitrum https://github.com/devzeroaristhrottle/Aristhrottle-V1
 repadd Arbitrum https://github.com/dhruvldrp9/pendle-agent-mini-app
-repadd Arbitrum https://github.com/dropps07/tixets
-repadd Arbitrum https://github.com/fenol64/P.A.G.A
 repadd Arbitrum https://github.com/gohildevyaniba25/arb-liquidity
 repadd Arbitrum https://github.com/hemanthj257/ArbSky
 repadd Arbitrum https://github.com/hummusonrails/arbitrum-prisoners-dilemma-workshop
@@ -51,7 +42,6 @@ repadd Arbitrum https://github.com/isha-bagadiya/lending-agent-farcaster
 repadd Arbitrum https://github.com/isha-mistry/trading-signals-farcaster
 repadd Arbitrum https://github.com/jatinsahijwani/zkArb-sdk
 repadd Arbitrum https://github.com/josephlyu/TrufflePay
-repadd Arbitrum https://github.com/juancolchete/waveSend
 repadd Arbitrum https://github.com/kaushal3637/spendin
 repadd Arbitrum https://github.com/kaushal3637/stableUPI
 repadd Arbitrum https://github.com/kaushalya4s5s7/evm_packstack
@@ -64,7 +54,6 @@ repadd Arbitrum https://github.com/prajapati-yash/nexa
 repadd Arbitrum https://github.com/purvik6062/ai-agent-safe-core
 repadd Arbitrum https://github.com/rahul-rathore786/Arbitrum-Buildathon
 repadd Arbitrum https://github.com/rishi-tal-12/Island-Mystery
-repadd Arbitrum https://github.com/robin11110000/OG-gain
 repadd Arbitrum https://github.com/sarthakbansal7/Sampatti
 repadd Arbitrum https://github.com/shinobi-cash/shinobi.cash-contracts
 repadd Arbitrum https://github.com/shreyan001/EscrowGuild


### PR DESCRIPTION
Adding repositories from various:
- Hackathons
- Buildathons
- DevRel initiatives

We deduplicated and tried to remove all unavailable repos.