### PR TITLE
Add `mmaker/draft-irtf-cfrg-sigma-protocols` and `arkworks-rs/spongefish` to ZK proofs

### DIFF
--- a/migrations/2025-11-08T232301_add_draft-irtf-cfrg-sigma-protocols
+++ b/migrations/2025-11-08T232301_add_draft-irtf-cfrg-sigma-protocols
@@ -1,0 +1,2 @@
+repadd "Zero Knowledge Cryptography" https://github.com/mmaker/draft-irtf-cfrg-sigma-protocols
+repadd "Zero Knowledge Cryptography" https://github.com/arkworks-rs/spongefish


### PR DESCRIPTION
Hi there,

This PR adds two repositories related to Zero-Knowledge Proofs to the ecosystem:

* `mmaker/draft-irtf-cfrg-sigma-protocols` : https://github.com/mmaker/draft-irtf-cfrg-sigma-protocols
* `arkworks-rs/spongefish` : https://github.com/arkworks-rs/spongefish

Thanks!