### PR TITLE
fix: update repository name from 'kyber-rs' to 'kyber-nz'

### DIFF
--- a/migrations/2025-11-28T213401_add_pqc_rs
+++ b/migrations/2025-11-28T213401_add_pqc_rs
@@ -1,1 +1,1 @@
-repadd 'Post-Quantum Cryptography' https://github.com/nougzarm/kyber-rs
+repadd 'Post-Quantum Cryptography' https://github.com/nougzarm/kyber-nz


### PR DESCRIPTION
### Description

This PR updates the reference for the Kyber library repository.
The repository previously named `kyber-rs` has been renamed to `kyber-nz`.

### Changes

- Updated the repository URL entry to reflect the new crate identity.