### PR TITLE
add-sei-ecosystem

### DIFF
--- a/migrations/2025-12-10T235959_add_sei_ecosystem
+++ b/migrations/2025-12-10T235959_add_sei_ecosystem
@@ -269,169 +269,6 @@ repadd "Orderly Network" https://github.com/OrderlyNetwork/contract-evm
 repadd "Orderly Network" https://github.com/OrderlyNetwork/orderly-js-sdk-cra-template
 repadd Rubic https://github.com/Cryptorubic/rubic-app
 repadd Rubic https://github.com/Cryptorubic/DefiLlama-Adapters
-
-ecoadd Paypal
-repadd Paypal https://github.com/paypal/mocksy
-repadd Paypal https://github.com/paypal/tech-talks
-repadd Paypal https://github.com/paypal/paypal-access
-repadd Paypal https://github.com/paypal/spring-social-paypal-openidconnect
-repadd Paypal https://github.com/paypal/permissions-sdk-php
-repadd Paypal https://github.com/paypal/merchant-sdk-php
-repadd Paypal https://github.com/paypal/PayPal-iOS-SDK
-repadd Paypal https://github.com/paypal/ipn-code-samples
-repadd Paypal https://github.com/paypal/pdt-code-samples
-repadd Paypal https://github.com/paypal/PayPal-PHP-SDK
-repadd Paypal https://github.com/paypal/sdk-packages
-repadd Paypal https://github.com/paypal/here-sideloader-api-samples
-repadd Paypal https://github.com/paypal/keystone
-repadd Paypal https://github.com/paypal/PayPal-Android-SDK
-repadd Paypal https://github.com/paypal/skipto
-repadd Paypal https://github.com/paypal/genio-parser
-repadd Paypal https://github.com/paypal/genio
-repadd Paypal https://github.com/paypal/amcharts-accessibility-plugin
-repadd Paypal https://github.com/paypal/bootstrap-accessibility-plugin
-repadd Paypal https://github.com/paypal/PayPal-Cordova-Plugin
-repadd Paypal https://github.com/paypal/baler
-repadd Paypal https://github.com/paypal/gatt
-repadd Paypal https://github.com/paypal/nemo-core
-repadd Paypal https://github.com/paypal/nemo-view
-repadd Paypal https://github.com/paypal/nemo-drivex
-repadd Paypal https://github.com/paypal/nemo-docs
-repadd Paypal https://github.com/paypal/nemo-example-app
-repadd Paypal https://github.com/paypal/generator-nemo
-repadd Paypal https://github.com/paypal/nemo-screenshot
-repadd Paypal https://github.com/paypal/SeLion
-repadd Paypal https://github.com/paypal/cbflume
-repadd Paypal https://github.com/paypal/couchbasekafka
-repadd Paypal https://github.com/paypal/nemo-browsermob-proxy
-repadd Paypal https://github.com/paypal/Illuminator
-repadd Paypal https://github.com/paypal/legalize.js
-repadd Paypal https://github.com/paypal/selenium-drivex
-repadd Paypal https://github.com/paypal/AATT
-repadd Paypal https://github.com/paypal/nemo-accessibility
-repadd Paypal https://github.com/paypal/react-engine
-repadd Paypal https://github.com/paypal/paypal-retail-node
-repadd Paypal https://github.com/paypal/generator-react-engine
-repadd Paypal https://github.com/paypal/squbs
-repadd Paypal https://github.com/paypal/InnerSourceCommons
-repadd Paypal https://github.com/paypal/nemo-wd-bridge
-repadd Paypal https://github.com/paypal/nemo-appium
-repadd Paypal https://github.com/paypal/seifrng
-repadd Paypal https://github.com/paypal/seifnode
-repadd Paypal https://github.com/paypal/docker-selion
-repadd Paypal https://github.com/paypal/TLS-update
-repadd Paypal https://github.com/paypal/resteasy-spring-boot
-repadd Paypal https://github.com/paypal/squbs-scala-seed.g8
-repadd Paypal https://github.com/paypal/squbs-java-seed.g8
-repadd Paypal https://github.com/paypal/gnomon
-repadd Paypal https://github.com/paypal/manticore-native
-repadd Paypal https://github.com/paypal/seif-protocol
-repadd Paypal https://github.com/paypal/releasinator
-repadd Paypal https://github.com/paypal/Gibberish-Detector-Java
-repadd Paypal https://github.com/paypal/gorealis
-repadd Paypal https://github.com/paypal/paypal-checkout-components
-repadd Paypal https://github.com/paypal/rallyslack
-repadd Paypal https://github.com/paypal/MrGerkins
-repadd Paypal https://github.com/paypal/IgniteTraining
-repadd Paypal https://github.com/paypal/fixo
-repadd Paypal https://github.com/paypal/nemo-fixo
-repadd Paypal https://github.com/paypal/paypalcheckout-ios
-repadd Paypal https://github.com/paypal/paypalcheckout-android
-repadd Paypal https://github.com/paypal/mock-meddleware
-repadd Paypal https://github.com/paypal/autosklearn-zeroconf
-repadd Paypal https://github.com/paypal/digraph-parser
-repadd Paypal https://github.com/paypal/nemo-runner
-repadd Paypal https://github.com/paypal/paypal-checkout-demo
-repadd Paypal https://github.com/paypal/paypal-bttn
-repadd Paypal https://github.com/paypal/glamorous
-repadd Paypal https://github.com/paypal/fullstack-phone
-repadd Paypal https://github.com/paypal/dce-go
-repadd Paypal https://github.com/paypal/openapilint
-repadd Paypal https://github.com/paypal/seazme-hub
-repadd Paypal https://github.com/paypal/generator-kraken-react
-repadd Paypal https://github.com/paypal/butterfly
-repadd Paypal https://github.com/paypal/paypal-sdk-client
-repadd Paypal https://github.com/paypal/nemo
-repadd Paypal https://github.com/paypal/homebrew-butterfly
-repadd Paypal https://github.com/paypal/seazme-sources
-repadd Paypal https://github.com/paypal/seazme-search
-repadd Paypal https://github.com/paypal/seazme
-repadd Paypal https://github.com/paypal/paypal-sdk-release
-repadd Paypal https://github.com/paypal/paypal-example-components
-repadd Paypal https://github.com/paypal/ec-via-braintreesdk-php-demo
-repadd Paypal https://github.com/paypal/gimel
-repadd Paypal https://github.com/paypal/paypal-card-components
-repadd Paypal https://github.com/paypal/ec-via-braintreesdk-java-demo
-repadd Paypal https://github.com/paypal/payflow-gateway
-repadd Paypal https://github.com/paypal/NNAnalytics
-repadd Paypal https://github.com/paypal/clover
-repadd Paypal https://github.com/paypal/paypal-here-ios-jasidepanels
-repadd Paypal https://github.com/paypal/PPExtensions
-repadd Paypal https://github.com/paypal/paypal-sdk-constants
-repadd Paypal https://github.com/paypal/Checkout-PHP-SDK
-repadd Paypal https://github.com/paypal/paypal-sdk-logos
-repadd Paypal https://github.com/paypal/paypal-muse-components
-repadd Paypal https://github.com/paypal/yurita
-repadd Paypal https://github.com/paypal/hera
-repadd Paypal https://github.com/paypal/paypal-common-components
-repadd Paypal https://github.com/paypal/paypal-messaging-components
-repadd Paypal https://github.com/paypal/paypal-funding-components
-repadd Paypal https://github.com/paypal/mobile-checkout-docs
-repadd Paypal https://github.com/paypal/HidLibrary
-repadd Paypal https://github.com/paypal/paypal-sample-merchant-server
-repadd Paypal https://github.com/paypal/paypalhttp_php
-repadd Paypal https://github.com/paypal/paypalhttp_dotnet
-repadd Paypal https://github.com/paypal/paypalhttp_java
-repadd Paypal https://github.com/paypal/paypalhttp_python
-repadd Paypal https://github.com/paypal/paypalhttp_ruby
-repadd Paypal https://github.com/paypal/paypalhttp_node
-repadd Paypal https://github.com/paypal/scorebot
-repadd Paypal https://github.com/paypal/Payouts-PHP-SDK
-repadd Paypal https://github.com/paypal/Payouts-DotNet-SDK
-repadd Paypal https://github.com/paypal/Payouts-Java-SDK
-repadd Paypal https://github.com/paypal/Payouts-Python-SDK
-repadd Paypal https://github.com/paypal/paypal-risk-data-collector
-repadd Paypal https://github.com/paypal/paypal-identity-components
-repadd Paypal https://github.com/paypal/paypalcheckout-samples-ios
-repadd Paypal https://github.com/paypal/android-checkout-sdk
-repadd Paypal https://github.com/paypal/PayPal-FPTI-Analytics
-repadd Paypal https://github.com/paypal/paypal-js
-repadd Paypal https://github.com/paypal/react-paypal-js
-repadd Paypal https://github.com/paypal/paypal-installments
-repadd Paypal https://github.com/paypal/load-watcher
-repadd Paypal https://github.com/paypal/heap-dump-tool
-repadd Paypal https://github.com/paypal/katbox
-repadd Paypal https://github.com/paypal/integration-packs
-repadd Paypal https://github.com/paypal/mocca
-repadd Paypal https://github.com/paypal/mirakl-hyperwallet-connector
-repadd Paypal https://github.com/paypal/paypal-sdk-e2e-tests
-repadd Paypal https://github.com/paypal/dione
-repadd Paypal https://github.com/paypal/paypal-android
-repadd Paypal https://github.com/paypal/paypal-ios
-repadd Paypal https://github.com/paypal/paypal-sdk-samples
-repadd Paypal https://github.com/paypal/Iguanas-docs
-repadd Paypal https://github.com/paypal/gators
-repadd Paypal https://github.com/paypal/paypal-personalization
-repadd Paypal https://github.com/paypal/postman-collections
-repadd Paypal https://github.com/paypal/paypal-legal-components
-repadd Paypal https://github.com/paypal/paypal-applepay-components
-repadd Paypal https://github.com/paypal/paypal-googlepay-component
-repadd Paypal https://github.com/paypal/junodb
-repadd Paypal https://github.com/paypal/data-contract-template
-repadd Paypal https://github.com/paypal/paypal-rest-api-specifications
-repadd Paypal https://github.com/paypal/paypal-messages-ios
-repadd Paypal https://github.com/paypal/paypal-messages-android
-repadd Paypal https://github.com/paypal/vscode-paypal
-repadd Paypal https://github.com/paypal/.github
-repadd Paypal https://github.com/paypal/PayPal-Ruby-Server-SDK
-repadd Paypal https://github.com/paypal/PayPal-Dotnet-Server-SDK
-repadd Paypal https://github.com/paypal/PayPal-PHP-Server-SDK
-repadd Paypal https://github.com/paypal/PayPal-Python-Server-SDK
-repadd Paypal https://github.com/paypal/PayPal-Java-Server-SDK
-repadd Paypal https://github.com/paypal/PayPal-TypeScript-Server-SDK
-repadd Paypal https://github.com/paypal/PayPal-Server-SDKs
-repadd Paypal https://github.com/paypal/agent-toolkit
-repadd Paypal https://github.com/paypal/paypal-mcp-server
 repadd "Sablier Finance" https://github.com/sablier-labs/legacy-contracts
 repadd "Sablier Finance"  https://github.com/sablier-labs/indexers
 repadd "Sablier Finance" https://github.com/sablier-labs/sdk
@@ -1008,8 +845,6 @@ repadd Adappt https://github.com/Adappt-team/white-paper
 ecoadd Aethir
 repadd Aethir https://github.com/AethirApp/checker-client
 repadd Aethir https://github.com/AethirApp/libyxrtc
-ecoadd Arculus
-repadd Arculus https://github.com/Arculus-Holdings-L-L-C/cosmos-kit
 repadd Bitfinex https://github.com/bitfinexcom/NodeBB
 ecoadd Cambrian
 repadd Cambrian https://github.com/CambrianAgents/cambrian-plugin
@@ -1120,92 +955,7 @@ repadd "Zero1 Labs" https://github.com/z1labs/Cypher-Orbit
 repadd "Zero1 Labs" https://github.com/z1labs/Cypher-Infrastructure
 repadd "Zero1 Labs" https://github.com/z1labs/Cypher-Metamask-Snap
 repadd "Zero1 Labs" https://github.com/z1labs/assets
-repadd OpenSea https://github.com/projectopensea
-repadd OpenSea https://github.com/ProjectOpenSea/ethmoji-js
-repadd OpenSea https://github.com/ProjectOpenSea/opensea-creatures
-repadd OpenSea https://github.com/ProjectOpenSea/truffle-contract
-repadd OpenSea https://github.com/ProjectOpenSea/ethmoji-js-demo
-repadd OpenSea https://github.com/ProjectOpenSea/ethmoji-contracts
-repadd OpenSea https://github.com/ProjectOpenSea/wyvern-schemas
-repadd OpenSea https://github.com/ProjectOpenSea/wyvern-js
 repadd OpenSea https://github.com/ProjectOpenSea/opensea-js
-repadd OpenSea https://github.com/ProjectOpenSea/ships-log
-repadd OpenSea https://github.com/ProjectOpenSea/heroku-td-agent
-repadd OpenSea https://github.com/ProjectOpenSea/cryptotickets
-repadd OpenSea https://github.com/ProjectOpenSea/metadata-api-python
-repadd OpenSea https://github.com/ProjectOpenSea/metadata-api-nodejs
-repadd OpenSea https://github.com/ProjectOpenSea/opensea-erc1155
-repadd OpenSea https://github.com/ProjectOpenSea/ethdenver-workshop
-repadd OpenSea https://github.com/ProjectOpenSea/multi-token-standard
-repadd OpenSea https://github.com/ProjectOpenSea/embeddable-nfts
-repadd OpenSea https://github.com/ProjectOpenSea/search-ui
-repadd OpenSea https://github.com/ProjectOpenSea/opensea-whitelabel
-repadd OpenSea https://github.com/ProjectOpenSea/meta-transactions
-repadd OpenSea https://github.com/ProjectOpenSea/discord-moderator
-repadd OpenSea https://github.com/ProjectOpenSea/0x-fee-wrapper
-repadd OpenSea https://github.com/ProjectOpenSea/nft-tutorial
-repadd OpenSea https://github.com/ProjectOpenSea/stream-js
-repadd OpenSea https://github.com/ProjectOpenSea/web3.py
-repadd OpenSea https://github.com/ProjectOpenSea/klaytn-contracts
-repadd OpenSea https://github.com/ProjectOpenSea/seaport
-repadd OpenSea https://github.com/ProjectOpenSea/0x-tools
-repadd OpenSea https://github.com/ProjectOpenSea/pytest-django
-repadd OpenSea https://github.com/ProjectOpenSea/seaport-js
-repadd OpenSea https://github.com/ProjectOpenSea/boundary-chart
-repadd OpenSea https://github.com/ProjectOpenSea/seaport.py
-repadd OpenSea https://github.com/ProjectOpenSea/opensea-stream-discord-webhook
-repadd OpenSea https://github.com/ProjectOpenSea/pyexiv2
-repadd OpenSea https://github.com/ProjectOpenSea/SDWebImageSwiftUI
-repadd OpenSea https://github.com/ProjectOpenSea/anchorpy
-repadd OpenSea https://github.com/ProjectOpenSea/marketplace-benchmarks
-repadd OpenSea https://github.com/ProjectOpenSea/brownie
-repadd OpenSea https://github.com/ProjectOpenSea/masonic
-repadd OpenSea https://github.com/ProjectOpenSea/seaport-gossip
-repadd OpenSea https://github.com/ProjectOpenSea/terraform-aws-eks
-repadd OpenSea https://github.com/ProjectOpenSea/shipyard
-repadd OpenSea https://github.com/ProjectOpenSea/seaport-order-validator
-repadd OpenSea https://github.com/ProjectOpenSea/CoinGecko-Java
-repadd OpenSea https://github.com/ProjectOpenSea/eslint-plugin-relay
-repadd OpenSea https://github.com/ProjectOpenSea/seadrop
-repadd OpenSea https://github.com/ProjectOpenSea/kotlin-walletconnect-lib
-repadd OpenSea https://github.com/ProjectOpenSea/celery-batches
-repadd OpenSea https://github.com/ProjectOpenSea/next-translate
-repadd OpenSea https://github.com/ProjectOpenSea/next-safe-middleware
-repadd OpenSea https://github.com/ProjectOpenSea/domain-registry
-repadd OpenSea https://github.com/ProjectOpenSea/SDWebImageSVGNativeCoder
-repadd OpenSea https://github.com/ProjectOpenSea/jellyfish
-repadd OpenSea https://github.com/ProjectOpenSea/operator-filter-registry
-repadd OpenSea https://github.com/ProjectOpenSea/SIPs
-repadd OpenSea https://github.com/ProjectOpenSea/seaport-sol
-repadd OpenSea https://github.com/ProjectOpenSea/relay
-repadd OpenSea https://github.com/ProjectOpenSea/uWebSockets.js
-repadd OpenSea https://github.com/ProjectOpenSea/uWebSockets
-repadd OpenSea https://github.com/ProjectOpenSea/uSockets
-repadd OpenSea https://github.com/ProjectOpenSea/unleash-proxy-client-swift
-repadd OpenSea https://github.com/ProjectOpenSea/pytest-xml-report
-repadd OpenSea https://github.com/ProjectOpenSea/redeemables
-repadd OpenSea https://github.com/ProjectOpenSea/WalletConnectSwiftV2
-repadd OpenSea https://github.com/ProjectOpenSea/seaport-types
-repadd OpenSea https://github.com/ProjectOpenSea/seaport-core
-repadd OpenSea https://github.com/ProjectOpenSea/seaport-generic-adapter
-repadd OpenSea https://github.com/ProjectOpenSea/weth-converter
-repadd OpenSea https://github.com/ProjectOpenSea/aws-privateca-issuer
-repadd OpenSea https://github.com/ProjectOpenSea/shipyard-core
-repadd OpenSea https://github.com/ProjectOpenSea/developer-docs
-repadd OpenSea https://github.com/ProjectOpenSea/shipyard-example-project
-repadd OpenSea https://github.com/ProjectOpenSea/seaport-1.6
-repadd OpenSea https://github.com/ProjectOpenSea/seaport-deploy
-repadd OpenSea https://github.com/ProjectOpenSea/vercel-repros
-repadd OpenSea https://github.com/ProjectOpenSea/buy-sell-opensea-sdk-demo
-repadd OpenSea https://github.com/ProjectOpenSea/tstorish
-repadd OpenSea https://github.com/ProjectOpenSea/seaport-hooks
-repadd OpenSea https://github.com/ProjectOpenSea/rules_jvm_external
-repadd OpenSea https://github.com/ProjectOpenSea/Gifu
-repadd OpenSea https://github.com/ProjectOpenSea/opensea-mcp-next-sample
-repadd OpenSea https://github.com/ProjectOpenSea/merkle-distributor-svm
-repadd OpenSea https://github.com/ProjectOpenSea/solana-kmp
-repadd OpenSea https://github.com/ProjectOpenSea/sol4k
-ecoadd "Magic Eden"
 repadd "Magic Eden" https://github.com/magiceden/magiceden-sdk
 repadd "Magic Eden" https://github.com/magiceden/reservoir-indexer-public
 ecoadd "Jambo Network"
@@ -1378,7 +1128,6 @@ ecocon "Sei Network" Keyrock
 ecocon "Sei Network" Magna
 ecocon "Sei Network" Monaco
 ecocon "Sei Network" Morpho
-ecocon "Sei Network" Paypal
 ecocon "Sei Network" Securitize
 ecocon "Sei Network" "Steer Protocol"
 ecocon "Sei Network" Dynamic
@@ -1386,10 +1135,8 @@ ecocon "Sei Network" Particle
 ecocon "Sei Network" Privy
 ecocon "Sei Network" Capsule
 ecocon "Sei Network" Protofire
-ecocon "Sei Network" Bitkeep
 ecocon "Sei Network" "Leap Wallet"
 ecocon "Sei Network" Chainapsis
-ecocon "Sei Network" Rainbow
 ecocon "Sei Network" SafePal
 ecocon "Sei Network" Turnkey
 ecocon "Sei Network" Zeroin
@@ -1438,9 +1185,7 @@ ecocon "Sei Network" UpBit
 ecocon "Sei Network" WeBump
 ecocon "Sei Network" "Zero1 Labs"
 ecocon "Sei Network" Picasso
-ecocon "Sei Network" OpenSea
 ecocon "Sei Network" "Jambo Network"
 ecocon "Sei Network" JokeRace
 ecocon "Sei Network" 0xNextme
 ecocon "Sei Network" "Baishi AI"
-ecocon "Sei Network" Arculus


### PR DESCRIPTION
This PR adds the ecosystem projects of Sei 

**Summary of changes**
- Add repositories that exist on the Sei ecosystem
- Consists of wide range of projects from games, Defi applications to indexers etc

Migration validation:
```bash
open-dev-data validate -r ./migrations
┃ 487    Migrations
┃ 7554   Ecosystems
┃ 623494 Repos
┃ 662    Tags
```


The migrations check passes locally. 