### PR TITLE
Add AlgoFaucet (Algorand)

### DIFF
--- a/migrations/2025-12-18T120500_add_repo_algofaucet
+++ b/migrations/2025-12-18T120500_add_repo_algofaucet
@@ -1,0 +1,2 @@
+﻿-- Add AlgoFaucet (Algorand faucet UI)
+repadd Algorand https://github.com/algofaucet/algofaucet #faucet


### PR DESCRIPTION
Adds AlgoFaucet repository to Algorand ecosystem.\n\n- Repo: https://github.com/algofaucet/algofaucet