### PR TITLE
feat: add BasePaint Yearly Sets Market to Base ecosystem

### DIFF
--- a/migrations/2026-01-17T222000_add_basepaint_market
+++ b/migrations/2026-01-17T222000_add_basepaint_market
@@ -1,0 +1,2 @@
+-- BasePaint Bundle Marketplace: Smart contracts for NFT bundle trading on Base L2
+repadd Base https://github.com/devacc8/basepaint-market-contracts


### PR DESCRIPTION
## Summary
Add BasePaint Yearly Sets Market smart contracts to the Base ecosystem.

## About BasePaint Yearly Sets Market
Trade complete BasePaint yearly sets in atomic transactions on Base L2.

- **Architecture**: UUPS upgradeable proxy pattern
- **Standards**: ERC-1155 (NFTs), EIP-712 (signatures)
- **Features**: 
  - Approval-based listing (similar to OpenSea)
  - Gas-efficient off-chain offer signatures
  - Atomic validation for all 365 NFTs
  - Reentrancy guards, pausable, ownership controls

Repository: https://github.com/devacc8/basepaint-market-contracts