### PR TITLE
Rename taxonomy ecosystem from "Olas Protocol" to "Olena Protocol"

### DIFF
--- a/migrations/2026-02-27T161700_rename_olas_protocol_to_olena_protocol
+++ b/migrations/2026-02-27T161700_rename_olas_protocol_to_olena_protocol
@@ -1,0 +1,1 @@
+ecomov "Olas Protocol" "Olena Protocol"


### PR DESCRIPTION
### Description
This PR updates the taxonomy ecosystem name:

`ecomov "Olas Protocol" "Olena Protocol"
`

### Context:
The repository URL migrations from olas-protocol/* to olena-protocol/* are already present in [migrations/2026-02-23T170938_mutations](https://github.com/electric-capital/open-dev-data/blob/master/migrations/2026-02-23T170938_mutations).
This change aligns the ecosystem label with the already-migrated repo URLs so data is shown under Olena Protocol instead of Olas Protocol.

Migration added

`migrations/2026-02-27T161700_rename_olas_protocol_to_olena_protocol`