### PR TITLE
Add CYM Rewards to Conflux ecosystem

### DIFF
--- a/migrations/20-04-2026T000001_CYM-Rewards_ConfluxSubmission
+++ b/migrations/20-04-2026T000001_CYM-Rewards_ConfluxSubmission
@@ -1,1 +1,1 @@
-repadd Conflux https://github.com/intrepidcanadian/cymstudios
+repadd "Conflux Network" https://github.com/intrepidcanadian/cymstudios

--- a/migrations/20-04-2026T000001_CYM-Rewards_ConfluxSubmission
+++ b/migrations/20-04-2026T000001_CYM-Rewards_ConfluxSubmission
@@ -1,0 +1,1 @@
+repadd Conflux https://github.com/intrepidcanadian/cymstudios


### PR DESCRIPTION
## Summary

Adds `https://github.com/intrepidcanadian/cymstudios` to the **Conflux** ecosystem.

## About the project

[CYM Rewards](https://cymstudio.app/catalogue) is a tournament prize redemption catalogue built for Conflux Network's [Global Hackfest 2026](https://github.com/conflux-fans/global-hackfest-2026) (Best USDT0 integration category).

Gasless gift-card redemptions paid in USDT0 on Conflux eSpace. Tournament winners convert prize tokens into real-world gift cards across 300+ brands — buyers only need USDT0, never CFX. A shared x402 facilitator pays CFX gas via EIP-3009 `transferWithAuthorization`.

- **USDT0 contract** (Conflux eSpace): [`0xaf37E8B6C9ED7f6318979f56Fc287d76c30847ff`](https://evm.confluxscan.org/address/0xaf37e8b6c9ed7f6318979f56fc287d76c30847ff)
- **Facilitator wallet** (Conflux eSpace + Ethereum): [`0xc10561C1c0d718B3D362df9D510A1b4e4331a4Ee`](https://evm.confluxscan.org/address/0xc10561C1c0d718B3D362df9D510A1b4e4331a4Ee)
- **ERC-8004 agent registration**: agent ID `22628` on Ethereum mainnet, metadata at [ipfs://QmSSDUyTZZVwPo18BgaXeWQxDPSGsNFeLr79UcCUAfGELj](https://gateway.pinata.cloud/ipfs/QmSSDUyTZZVwPo18BgaXeWQxDPSGsNFeLr79UcCUAfGELj)
- **Native MCP endpoint** (JSON-RPC 2.0, 12 tools incl. agent-initiated purchase): `https://cymstudio.app/api/mcp/rewards`

## Migration

Adds a single `repadd Conflux` entry:

```
repadd Conflux https://github.com/intrepidcanadian/cymstudios
```