### PR TITLE
Add Chaupar On-Chain to Conflux ecosystem

### DIFF
--- a/migrations/2026-04-20T220600_chaupar_onchain
+++ b/migrations/2026-04-20T220600_chaupar_onchain
@@ -1,1 +1,1 @@
-rep_add Conflux https://github.com/manisaigaddam/chaupar
+repadd "Conflux Network" https://github.com/manisaigaddam/chaupar

--- a/migrations/2026-04-20T220600_chaupar_onchain
+++ b/migrations/2026-04-20T220600_chaupar_onchain
@@ -1,0 +1,1 @@
+repadd Conflux https://github.com/manisaigaddam/chaupar

--- a/migrations/2026-04-20T220600_chaupar_onchain
+++ b/migrations/2026-04-20T220600_chaupar_onchain
@@ -1,1 +1,1 @@
-repadd Conflux https://github.com/manisaigaddam/chaupar
+rep_add Conflux https://github.com/manisaigaddam/chaupar


### PR DESCRIPTION
Adding Chaupar On-Chain to the Conflux ecosystem developer metrics for Global Hackfest 2026.

- Project Name: Chaupar On-Chain
- Ecosystem: Conflux
- Repository: https://github.com/manisaigaddam/chaupar
