### PR TITLE
Add reCFX to Conflux ecosystem

### DIFF
--- a/migrations/2026-04-20T120000_confluxmind
+++ b/migrations/2026-04-20T120000_confluxmind
@@ -1,1 +1,1 @@
-repadd Conflux https://github.com/Najnomics/ConfluxMind #protocol
+repadd "Conflux Network" https://github.com/Najnomics/ConfluxMind #protocol

--- a/migrations/2026-04-20T120000_confluxmind
+++ b/migrations/2026-04-20T120000_confluxmind
@@ -1,0 +1,1 @@
+repadd Conflux https://github.com/Najnomics/ConfluxMind #protocol

--- a/migrations/2026-04-21T120000_reCFX/migration
+++ b/migrations/2026-04-21T120000_reCFX/migration
@@ -1,0 +1,1 @@
+repadd Conflux https://github.com/Najnomics/reCFX #protocol

--- a/migrations/2026-04-21T120000_reCFX/migration
+++ b/migrations/2026-04-21T120000_reCFX/migration
@@ -1,1 +1,1 @@
-repadd Conflux https://github.com/Najnomics/reCFX #protocol
+repadd "Conflux Network" https://github.com/Najnomics/reCFX #protocol


### PR DESCRIPTION
Adding reCFX — the first liquid restaking protocol on Conflux eSpace.

- **Repository**: https://github.com/Najnomics/reCFX
- **Ecosystem**: Conflux
- **Category**: Protocol (DeFi / Restaking)
- **Hackathon**: Global Hackfest 2026