### PR TITLE
Add MultiversX agentic-commerce repos (x402, MCP, AP2, ACP)

### DIFF
--- a/migrations/2026-05-07T151159_add_multiversx_agentic_commerce_repos
+++ b/migrations/2026-05-07T151159_add_multiversx_agentic_commerce_repos
@@ -1,0 +1,19 @@
+-- Adds 12 repositories from the multiversx/* org covering MultiversX's
+-- 2025-2026 agentic-commerce work: x402 payments, MCP server, OpenAI ACP
+-- adapter, Google AP2, Agent2Agent + x402 bridge, MultiversX agent standard
+-- (ERC-8004 equivalent), OpenClaw relayer/skills, AI skills knowledge base,
+-- and the Battle of Nodes Supernova scripts. All repos are public,
+-- non-archived, non-fork, and have commits in the last 90 days from core
+-- MultiversX contributors.
+repadd "MultiversX (Elrond)" https://github.com/multiversx/mx-mcp-server #sdk
+repadd "MultiversX (Elrond)" https://github.com/multiversx/mx-x402
+repadd "MultiversX (Elrond)" https://github.com/multiversx/mx-x402-facilitator
+repadd "MultiversX (Elrond)" https://github.com/multiversx/mx-AP2
+repadd "MultiversX (Elrond)" https://github.com/multiversx/mx-acp-adapter
+repadd "MultiversX (Elrond)" https://github.com/multiversx/mx-a2a-x402
+repadd "MultiversX (Elrond)" https://github.com/multiversx/mx-agent-standard
+repadd "MultiversX (Elrond)" https://github.com/multiversx/mx-agentic-commerce-tests
+repadd "MultiversX (Elrond)" https://github.com/multiversx/mx-openclaw-relayer
+repadd "MultiversX (Elrond)" https://github.com/multiversx/mx-openclaw-skills
+repadd "MultiversX (Elrond)" https://github.com/multiversx/mx-ai-skills
+repadd "MultiversX (Elrond)" https://github.com/multiversx/mx-bon-supernova-scripts


### PR DESCRIPTION
Adds 12 repositories from the `multiversx/*` org covering MultiversX's
2025-2026 agentic-commerce work — the chain's primary 2026 development
focus. All repos are public, non-archived, non-forks, and have commits
in the last 90 days.

The cluster:

- `multiversx/mx-mcp-server` — official Model Context Protocol server
  for MultiversX (AI agent ↔ blockchain integration). Tagged `#sdk`.
- `multiversx/mx-x402` — x402 payments-protocol implementation.
- `multiversx/mx-x402-facilitator` — off-chain verification & settlement
  service for x402.
- `multiversx/mx-AP2` — Agent Payments Protocol (Google AP2) samples.
- `multiversx/mx-acp-adapter` — adapter implementing OpenAI's Agentic
  Commerce Protocol on MultiversX.
- `multiversx/mx-a2a-x402` — A2A protocol extension bringing on-chain
  payments to agent-to-agent flows.
- `multiversx/mx-agent-standard` — MultiversX agent standard
  (identity registry, trust layer, x402 payments, MCP integration).
- `multiversx/mx-agentic-commerce-tests` — integration test suite for
  the full agentic-commerce stack.
- `multiversx/mx-openclaw-relayer` — relayer service for OpenClaw
  agents (Relayed V3 transactions).
- `multiversx/mx-openclaw-skills` — agent-facing skill registry for
  OpenClaw.
- `multiversx/mx-ai-skills` — AI skills/knowledge base for MultiversX
  development.
- `multiversx/mx-bon-supernova-scripts` — scripts for the Battle of
  Nodes Supernova (sub-second blocks) testnet.

### Verification

- All 12 repos resolve at `github.com/multiversx/*` (the official org).
- All have commits within the last 90 days.
- None are archived; none are forks.
- Conservative tagging: only `mx-mcp-server` carries `#sdk`. The rest
  are untagged, matching the existing tag sparsity across the
  MultiversX (Elrond) ecosystem.
- `multiversx/mx-8004` was deliberately excluded from this PR because it
  is already attributed (via an earlier migration).

### Validation

`open-dev-data validate -r ./migrations` passes. Delta vs. upstream
master: +1 migration, +12 repos.