### PR TITLE
Add Base Pay Desk site to Base

### DIFF
--- a/migrations/2026-05-12T120000_add_base_pay_desk_site
+++ b/migrations/2026-05-12T120000_add_base_pay_desk_site
@@ -1,0 +1,1 @@
+repadd Base https://github.com/oskarasi/base-pay-desk-site


### PR DESCRIPTION
Adds the public Base Pay Desk static deployment repo to the Base ecosystem taxonomy.

Scope:
- adds only the public GitHub Pages repo: https://github.com/oskarasi/base-pay-desk-site
- does not add the private source repo
- does not claim traction or deployed router activity

Validation:
- git diff --check passed
- UV_CACHE_DIR=/private/tmp/uv-cache-open-dev-data uvx open-dev-data validate -r ./migrations currently fails on two pre-existing upstream migrations: ./migrations/2026-03-04T120948_mutations:9898 error.InvalidSourceRepo and ./migrations/2026-04-08T165859_mutations:15797 error.InvalidSourceRepo