### PR TITLE
Add Swarm Economy (agentic-crypto-swarm) to Celo ecosystem

### DIFF
--- a/migrations/2026-05-24T151854_add_swarm_economy_celo
+++ b/migrations/2026-05-24T151854_add_swarm_economy_celo
@@ -1,0 +1,1 @@
+repadd Celo https://github.com/Hobie1Kenobi/agentic-crypto-swarm-prototype #developer-tool


### PR DESCRIPTION
Adds Hobie1Kenobi/agentic-crypto-swarm-prototype to the Celo ecosystem taxonomy.

Submitted for celo-org/gitcoin#54 bounty.

Payout Celo address on file with bounty submission.

Made with [Cursor](https://cursor.com)