### PR TITLE
Fix stray "error." prefix in validation error output

### DIFF
--- a/src/open_dev_data/taxonomy.py
+++ b/src/open_dev_data/taxonomy.py
@@ -531,7 +531,7 @@ class Taxonomy:
         """Print all errors to stderr."""
         for error in self.errors:
             print(
-                f"{error.path}:{error.line_num}: error.{error.message}", file=sys.stderr
+                f"{error.path}:{error.line_num}: {error.message}", file=sys.stderr
             )
 
     def _tag_strings_for_eco_repo(


### PR DESCRIPTION
## Summary

`_print_errors()` in `taxonomy.py` had a literal `error.` inside the f-string before the interpolated message. Validation errors printed as `path:line: error.DuplicateRepo` instead of `path:line: DuplicateRepo`.

This is on the live error path: `run.sh validate` → `open-dev-data validate` → `_print_errors()`, so it shows up in CI output whenever a migration fails validation.

Note: this is a cosmetic fix (a stray prefix). The error message itself was always printing correctly — contrary to #2880, the value was interpolated, and the `error.ValidationFailed` output described in the issue is not something this code can produce. `error.message` holds the caught exception's class name.

Closes #2880

🤖 Generated with [Claude Code](https://claude.com/claude-code)