### PR TITLE
Add TRELYAN Falcon-1024 inscription reference (Algorand)

### DIFF
--- a/migrations/2026-06-02T120000_add_trelyan_falcon_inscription
+++ b/migrations/2026-06-02T120000_add_trelyan_falcon_inscription
@@ -1,0 +1,1 @@
+repadd Algorand https://github.com/brandonjsellam-Releone/trelyan-falcon-inscription #developer-tool


### PR DESCRIPTION
Adds the open-source TRELYAN Falcon-1024 inscription reference to the Algorand ecosystem.

Repo: https://github.com/brandonjsellam-Releone/trelyan-falcon-inscription (MIT)

An open reference implementation for Algorand's native falcon_verify opcode: a post-quantum (Falcon-1024) on-chain inscription contract with tests, docs, and a one-command TestNet deploy. Single repadd under Algorand, tagged #developer-tool.