### PR TITLE
make run script pass args to validate command

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -43,7 +43,7 @@ run_cmd() {
 }
 
 validate() {
-    run_cmd open-dev-data validate
+    run_cmd open-dev-data validate "${@}"
 }
 
 export_taxonomy() {
@@ -61,6 +61,7 @@ help() {
 # Main script logic
 case "$1" in
     "validate")
+        shift
         validate "$@"
         ;;
     "export")

--- a/src/open_dev_data/commands.py
+++ b/src/open_dev_data/commands.py
@@ -22,10 +22,10 @@ def print_usage() -> None:
 
 Commands:
   validate                 Validate all of the migrations
-      -r, --root DIR       The direction containing the migrations file (default ./migrations)
+      -r, --root DIR       The directory containing the migrations file (default ./migrations)
 
   export                   Export the taxonomy to a json file
-      -r, --root DIR       The direction containing the migrations file (default ./migrations)
+      -r, --root DIR       The directory containing the migrations file (default ./migrations)
       -e, --ecosystem STR  The name of an ecosystem if you only want to export one
       -m, --max-date STR   The maximum date to run migrations until.
                            One can export the taxonomy state at specific past dates with this param.


### PR DESCRIPTION
While I was working on #2889, I noticed the `run.sh` script doesn't pass through CLI arguments to the `validate` command. I was attempting to validate a migration file in its own directory, but when I ran `./run.sh validate --root ./somedir`, it was still running the validation only on the default (`./migrations`) directory. I'm passing through the arguments, exactly the same way the `export` command does.

I also noticed a couple typos in the `--help` text, so I've fixed those, as well. If that's overreaching for this simple fix, I can revert that one.

Let me know if this PR needs anything. Thanks!