### PR TITLE
Add OpenChainBench

### DIFF
--- a/migrations/2026-06-11T120000_add_openchainbench
+++ b/migrations/2026-06-11T120000_add_openchainbench
@@ -1,0 +1,3 @@
+ecoadd OpenChainBench
+ecocon "Multichain Infrastructure" OpenChainBench
+repadd OpenChainBench https://github.com/ChainBench/OpenChainBench #developer-tool


### PR DESCRIPTION
This adds OpenChainBench, an open source benchmark suite for crypto infrastructure (RPC providers, aggregators, bridges) covering Ethereum, Base, Solana, Arbitrum and BNB Chain among others.

Migration adds the OpenChainBench ecosystem, connects it under Multichain Infrastructure since it spans several chains, and adds the repo with the #developer-tool tag.

Repo: https://github.com/ChainBench/OpenChainBench (MIT, TypeScript)
Site: https://openchainbench.com

Validated locally with ./run.sh validate.