### PR TITLE
Add Ophis (intent-based DEX aggregator built on CoW Protocol)

### DIFF
--- a/migrations/2026-06-13T120000_add_ophis
+++ b/migrations/2026-06-13T120000_add_ophis
@@ -1,0 +1,22 @@
+-- Add Ophis: intent-based DEX aggregator built on CoW Protocol, with an agent-native layer.
+-- Repo: https://github.com/ophis-fi/ophis (open source).
+-- Create the Ophis project ecosystem and register its repository.
+ecoadd Ophis
+repadd Ophis https://github.com/ophis-fi/ophis "#protocol"
+
+-- Connect Ophis under the ecosystems it builds on / serves.
+-- Ophis self-hosts CoW Protocol settlement on Optimism and routes the other major
+-- chains through the CoW solver network.
+ecocon "Multichain Infrastructure" Ophis
+ecocon "EVM Multichain dApps" Ophis
+ecocon Ethereum Ophis
+ecocon Optimism Ophis
+ecocon Arbitrum Ophis
+ecocon Base Ophis
+ecocon Polygon Ophis
+ecocon Avalanche Ophis
+ecocon BNB Ophis
+ecocon "Gnosis Chain" Ophis
+ecocon Linea Ophis
+ecocon Plasma Ophis
+ecocon Ink Ophis


### PR DESCRIPTION
Adds the Ophis open-source repository (https://github.com/ophis-fi/ophis) to the taxonomy.

Ophis is an intent-based DEX aggregator built on CoW Protocol that adds an agent-native layer (natural-language intents, an MCP server, a TypeScript SDK, an embeddable widget). It self-hosts CoW Protocol settlement on Optimism and routes the other major chains through the CoW solver network.

This migration creates a dedicated `Ophis` ecosystem, registers the repo under it (matching the convention used for Aave, 1inch, and Cow Swap), and connects Ophis as a sub-ecosystem of every chain it serves (Ethereum, Optimism, Arbitrum, Base, Polygon, Avalanche, BNB, Gnosis Chain, Linea, Plasma, Ink) plus the Multichain Infrastructure / EVM Multichain dApps buckets.

Validated locally against the live tree: `./run.sh validate` (zero errors; 737 migrations / 7657 ecosystems / 735069 repos) and `./run.sh test` (28 passed). `./run.sh export -e Ophis` returns the Ophis repo with its `#protocol` tag.