### PR TITLE
Add Lrifton92 repos: droprank (Base), shipquests (Celo)

### DIFF
--- a/migrations/2026-06-15T120000_add_lrifton92_repos
+++ b/migrations/2026-06-15T120000_add_lrifton92_repos
@@ -1,0 +1,5 @@
+-- Add Lrifton92 crypto projects to their respective ecosystems
+-- DropRank: Base airdrop score & quest radar mini-app (Base mini-app, OnchainKit/wagmi/viem)
+repadd Base https://github.com/Lrifton92/droprank
+-- ShipQuests: Proof of Ship onchain quests on Celo
+repadd Celo https://github.com/Lrifton92/shipquests


### PR DESCRIPTION
Adds two of my own public crypto projects to the taxonomy via a single migration.

| Repo | Ecosystem | What it is |
|------|-----------|------------|
| https://github.com/Lrifton92/droprank | Base | Base airdrop score & quest radar mini-app (OnchainKit / wagmi / viem) |
| https://github.com/Lrifton92/shipquests | Celo | Proof of Ship onchain quests on Celo |

Both repos are public, original (not forks), and contain real onchain/web3 code.

Validated locally with `./run.sh validate` (737 migrations, 0 errors) and confirmed via `./run.sh export` that both repos resolve under Base and Celo respectively.