### PR TITLE
Add Dexly Hyperliquid ecosystem repos

### DIFF
--- a/migrations/2026-07-09T112152_add_dexly_hyperliquid_repos
+++ b/migrations/2026-07-09T112152_add_dexly_hyperliquid_repos
@@ -1,0 +1,3 @@
+-- Add Dexly (self-custodial Hyperliquid mobile trading app) open-source repositories
+repadd Hyperliquid https://github.com/dexlytrade/hyperliquid-funding-rates
+repadd Hyperliquid https://github.com/dexlytrade/awesome-tokenized-stocks

--- a/migrations/2026-07-09T112152_add_dexly_hyperliquid_repos
+++ b/migrations/2026-07-09T112152_add_dexly_hyperliquid_repos
@@ -1,3 +1,5 @@
 -- Add Dexly (self-custodial Hyperliquid mobile trading app) open-source repositories
 repadd Hyperliquid https://github.com/dexlytrade/hyperliquid-funding-rates
 repadd Hyperliquid https://github.com/dexlytrade/awesome-tokenized-stocks
+repadd Hyperliquid https://github.com/dexlytrade/hyperliquid-spot-screener
+repadd Hyperliquid https://github.com/dexlytrade/awesome-hyperliquid-copy-trading


### PR DESCRIPTION
Adds two public open-source repositories maintained by the Dexly team (a self-custodial mobile app for trading on Hyperliquid) to the Hyperliquid ecosystem:

- dexlytrade/hyperliquid-funding-rates — a zero-dependency Python CLI that reads Hyperliquid's public API for live funding rates, open interest and 24h volume.
- - dexlytrade/awesome-tokenized-stocks — a curated list of tokenized-stock / RWA platforms, including Hyperliquid-based venues.
Both repositories are public and MIT/CC0 licensed. Not affiliated with Hyperliquid.