### PR TITLE
Add b20crunch to Base ecosystem

### DIFF
--- a/migrations/2026-07-09T191510_add_b20crunch_to_base
+++ b/migrations/2026-07-09T191510_add_b20crunch_to_base
@@ -1,0 +1,1 @@
+repadd Base https://github.com/wayzeek/b20crunch


### PR DESCRIPTION
Adds https://github.com/wayzeek/b20crunch, an open source Rust CLI for mining B20 vanity token addresses on Base, to the Base ecosystem. Validated with ./run.sh validate.