### PR TITLE
Add x402 ecosystem

### DIFF
--- a/migrations/2026-07-11T160000_add_x402_ecosystem
+++ b/migrations/2026-07-11T160000_add_x402_ecosystem
@@ -1,0 +1,24 @@
+-- Add the x402 ecosystem: the HTTP 402 "Payment Required" machine-to-machine
+-- payments protocol (x402 Foundation, a Linux Foundation project).
+-- x402 settles primarily on Base today, with Solana support emerging.
+ecoadd x402
+ecocon Base x402
+ecocon Solana x402
+-- Core protocol repositories
+repadd x402 https://github.com/x402-foundation/x402 #protocol
+repadd x402 https://github.com/coinbase/x402 #protocol
+-- Ecosystem explorers and protocol extensions
+repadd x402 https://github.com/Merit-Systems/x402scan
+repadd x402 https://github.com/google-agentic-commerce/a2a-x402
+-- Independent measurement, verification and developer tooling
+repadd x402 https://github.com/smartflowproai-lang/x402-attribution-ref
+repadd x402 https://github.com/smartflowproai-lang/x402-b20-exact
+repadd x402 https://github.com/smartflowproai-lang/x402-endpoint-validator
+repadd x402 https://github.com/smartflowproai-lang/pqs-verify
+repadd x402 https://github.com/smartflowproai-lang/mapper-mcp
+repadd x402 https://github.com/smartflowproai-lang/smartflow-observatory-methodology
+repadd x402 https://github.com/smartflowproai-lang/x402-saas-starter
+repadd x402 https://github.com/smartflowproai-lang/quorum
+repadd x402 https://github.com/smartflowproai-lang/solana-x402-scanner
+repadd x402 https://github.com/smartflowproai-lang/solana-x402-facilitator
+repadd x402 https://github.com/smartflowproai-lang/n8n-nodes-x402

--- a/migrations/2026-07-11T160000_add_x402_ecosystem
+++ b/migrations/2026-07-11T160000_add_x402_ecosystem
@@ -11,6 +11,7 @@ repadd x402 https://github.com/coinbase/x402 #protocol
 repadd x402 https://github.com/Merit-Systems/x402scan
 repadd x402 https://github.com/google-agentic-commerce/a2a-x402
 -- Independent measurement, verification and developer tooling
+repadd x402 https://github.com/smartflowproai-lang/b20-census
 repadd x402 https://github.com/smartflowproai-lang/x402-attribution-ref
 repadd x402 https://github.com/smartflowproai-lang/x402-b20-exact
 repadd x402 https://github.com/smartflowproai-lang/x402-endpoint-validator


### PR DESCRIPTION
x402, the HTTP 402 "Payment Required" machine-to-machine payments protocol (x402 Foundation, a Linux Foundation project), is currently absent from the taxonomy: no ecosystem entry and none of its repositories are counted.

This migration adds:
- the x402 ecosystem, connected as a sub-ecosystem of Base and Solana (primary settlement chains today)
- core protocol repos (x402-foundation/x402, coinbase/x402)
- ecosystem tooling (Merit-Systems/x402scan explorer, google-agentic-commerce/a2a-x402 extension)
- our open-source measurement and verification tooling for the protocol (SmartFlow Observatory: attribution spec, endpoint validator, catalogue MCP server, methodology queries, scanners)

All repository URLs verified live before submission.
