### PR TITLE
Add algonaut Algorand repo

### DIFF
--- a/migrations/2026-07-13T120554_add_repo_algonaut
+++ b/migrations/2026-07-13T120554_add_repo_algonaut
@@ -1,0 +1,1 @@
+repadd Algorand https://github.com/manuelmauro/algonaut


### PR DESCRIPTION
Adds the [algonaut](https://github.com/manuelmauro/algonaut) repository to the Algorand ecosystem.

## Changes

New migration `migrations/2026-07-13T120554_add_repo_algonaut`:

```
repadd Algorand https://github.com/manuelmauro/algonaut
```

`algonaut` is a Rust SDK for the Algorand blockchain. `Algorand` is an existing ecosystem, and `./run.sh validate` passes cleanly with the new migration applied.