### PR TITLE
Add eltociear (AI-agent security & x402 tools)

### DIFF
--- a/migrations/2026-07-15T173551_add_eltociear
+++ b/migrations/2026-07-15T173551_add_eltociear
@@ -1,0 +1,10 @@
+-- Add eltociear: open-source AI-agent security tools + x402 (USDC on Base) APIs
+ecoadd eltociear
+repadd eltociear https://github.com/eltociear/tokenguard-mcp
+repadd eltociear https://github.com/eltociear/contract-guard-mcp
+repadd eltociear https://github.com/eltociear/x402-approval-guard
+repadd eltociear https://github.com/eltociear/skill-audit-mcp
+repadd eltociear https://github.com/eltociear/secrets-audit-mcp
+repadd eltociear https://github.com/eltociear/mcp-security-audit-action
+-- Connect to Base (x402 endpoints settle in USDC on Base)
+ecocon Base eltociear


### PR DESCRIPTION
Adds **eltociear** — a set of open-source AI-agent security tools and pay-per-call x402 (USDC on Base) APIs — as an ecosystem connected to Base.

Repos:
- `tokenguard-mcp`, `contract-guard-mcp` — ERC-20 token & EVM contract safety checks
- `x402-approval-guard` — blocks dangerous ERC-20 approvals for AI agents
- `skill-audit-mcp`, `secrets-audit-mcp` — MCP server / agent-skill / leaked-secret scanners
- `mcp-security-audit-action` — GitHub Action for MCP security scanning

The tokenguard / contract-guard / skill-audit tools are also live as x402 pay-per-call endpoints settling in USDC on Base, hence the connection to the Base ecosystem.
