### PR TITLE
Remove stellar/winget-pkgs (fork of microsoft/winget-pkgs) from Stellar

### DIFF
--- a/migrations/2026-07-15T000000_reprem_stellar_winget_pkgs_fork
+++ b/migrations/2026-07-15T000000_reprem_stellar_winget_pkgs_fork
@@ -1,0 +1,9 @@
+-- Remove stellar/winget-pkgs from the Stellar ecosystem.
+-- It is a fork of microsoft/winget-pkgs (the Windows Package Manager manifest
+-- repo), created under the Stellar org to publish a package to winget (standard
+-- practice). The fork carries upstream's full contributor history (~1,440 active
+-- developers, 2 stars), inflating Stellar's developer counts with contributors
+-- who do no crypto work. 1,440 of those 1,444 appear in no other Stellar repo.
+-- Consistent with the prior removal of NethermindEth/winget-pkgs from Ethereum
+-- and Nethermind (migration 2025-05-01T112748_mutations).
+reprem Stellar https://github.com/stellar/winget-pkgs


### PR DESCRIPTION
# Remove stellar/winget-pkgs (fork of microsoft/winget-pkgs) from Stellar

## What
Adds a migration removing `https://github.com/stellar/winget-pkgs` from the
Stellar ecosystem.

```
reprem Stellar https://github.com/stellar/winget-pkgs
```

## Why
`stellar/winget-pkgs` is a **fork of `microsoft/winget-pkgs`** (the Windows
Package Manager manifest repo), created under the Stellar org to publish a
package to winget — standard practice. Because the fork carries upstream's full
contributor history, it pulls a large number of Windows-packaging contributors
into Stellar's developer counts:

- **~1,440 active developers** in the last 90 days, but only **2 stars**
- **1,440 of those 1,444 appear in no other Stellar repo**
- **≈27%** of Stellar's recent active developers in the current snapshot
  (`20260715T125411`)

None of these contributors do crypto work on Stellar — the attribution is purely
an artifact of the fork relationship.

## Precedent
This mirrors the prior removal of the equivalent Nethermind fork in
`migrations/2025-05-01T112748_mutations`:

```
reprem Ethereum https://github.com/NethermindEth/winget-pkgs
reprem Nethermind https://github.com/NethermindEth/winget-pkgs
```

## Verification
- `open-dev-data validate` passes.
- `open-dev-data export -e Stellar` **contains** the repo before this migration
  and **no longer contains it** after (A/B checked).
