### PR TITLE
Add Rugspull to BNB Chain ecosystem

### DIFF
--- a/migrations/2026-07-16T135434_add_rugspull
+++ b/migrations/2026-07-16T135434_add_rugspull
@@ -1,0 +1,3 @@
+ecoadd Rugspull
+repadd Rugspull https://github.com/pqchase/rugspull #protocol #defi #dex #solidity
+ecocon "BNB Chain" Rugspull


### PR DESCRIPTION
Adds Rugspull, an open-source BNB Chain protocol with an internal constant-product AMM, to the taxonomy and links its public repository under BNB Chain.

Validation:
- `open-dev-data validate -r migrations`
- Passed locally against 770 migrations, 7,662 ecosystems, 750,568 repos, and 1,109 tags.