### PR TITLE
Add SmartFlow Observatory x402 repositories to the x402 ecosystem

### DIFF
--- a/migrations/2026-07-17T203500_add_smartflow_x402_repos
+++ b/migrations/2026-07-17T203500_add_smartflow_x402_repos
@@ -1,0 +1,7 @@
+repadd x402 https://github.com/smartflowproai-lang/x402-attribution-ref
+repadd x402 https://github.com/smartflowproai-lang/x402-b20-exact
+repadd x402 https://github.com/smartflowproai-lang/x402-endpoint-validator
+repadd x402 https://github.com/smartflowproai-lang/mapper-mcp
+repadd x402 https://github.com/smartflowproai-lang/x402-saas-starter
+repadd x402 https://github.com/smartflowproai-lang/quorum
+repadd x402 https://github.com/smartflowproai-lang/solana-x402-scanner


### PR DESCRIPTION
This adds 7 repositories from the SmartFlow Observatory org to the existing x402 ecosystem. All are original (no forks), public, and active.

- x402-attribution-ref: attribution evidence envelope spec + conformance vectors (referenced as an adopter case in x402-foundation/x402#2335)
- x402-b20-exact: draft B20 AssetTransferMethod for the x402 exact scheme (gasless settlement on Base)
- x402-endpoint-validator: CI validator for x402 endpoint conformance (reachability, well-known manifest, 402 body)
- mapper-mcp: MCP server exposing an x402 endpoint catalogue (58,800+ endpoints)
- x402-saas-starter: pay-per-download starter using x402 micropayments on Base
- quorum: multi-agent mesh paying itself in x402 micropayments, anchoring on Base mainnet (ETHGlobal Open Agents 2026 submission)
- solana-x402-scanner: x402 endpoint scanner for Solana mainnet (already listed under Base/Solana/Ethereum, adding it to x402 as well)
