### PR TITLE
Add Abakos ecosystem

### DIFF
--- a/migrations/2026-07-25T180000_add_abakos
+++ b/migrations/2026-07-25T180000_add_abakos
@@ -1,0 +1,4 @@
+-- Add the Abakos ecosystem
+ecoadd Abakos
+-- Abakos: zero-fee EVM-compatible Proof-of-Stake compute chain (Akash/Cosmos-SDK fork) with an idle-hardware mining desktop app
+repadd Abakos https://github.com/Abakos-ABA/abakos


### PR DESCRIPTION
Adds **Abakos** as a new ecosystem.

Abakos is an open-source (MIT), zero-fee, EVM-compatible Proof-of-Stake compute chain — a fork of the Akash/Cosmos-SDK stack with a native EVM (chain id 9721), an on-chain DEX, and a desktop app that mines the most profitable coin on idle CPU/GPU and pays out on-chain.

- **Repo:** https://github.com/Abakos-ABA/abakos (active, public, MIT)
- Adds one migration `migrations/2026-07-25T180000_add_abakos` with `ecoadd Abakos` + `repadd Abakos <repo>`.
