### PR TITLE
Add WealthVille integrations to Solana ecosystem

### DIFF
--- a/migrations/2026-07-27T120000_add_wealthville
+++ b/migrations/2026-07-27T120000_add_wealthville
@@ -1,0 +1,5 @@
+-- WealthVille: open-source connectors for a Solana LP pool scoring / signal engine.
+-- MCP server (@wealthville/mcp-server), Solana Agent Kit plugin, and ElizaOS plugin.
+-- MIT licensed, TypeScript.
+
+repadd Solana https://github.com/amitesh-m/wealthville-integrations


### PR DESCRIPTION
Adds one open-source repository to the **Solana** ecosystem.

```
repadd Solana https://github.com/amitesh-m/wealthville-integrations
```

### What it is

[`wealthville-integrations`](https://github.com/amitesh-m/wealthville-integrations) holds the official open-source connectors for WealthVille, a liquidity-pool scoring and signal engine for Solana DEXes (Meteora DLMM, Orca Whirlpool, Raydium AMM/CLMM/CPMM). The repo contains three TypeScript packages:

- **MCP server** — `@wealthville/mcp-server` on npm, also listed in the official MCP registry and on Smithery. Exposes Solana LP pool scores, a signals feed and a track record as MCP tools.
- **Solana Agent Kit plugin** — pool-scoring tools for `sendaifun/solana-agent-kit`.
- **ElizaOS plugin** — `@wealthville/plugin-wealthville` on npm, already in the ElizaOS registry (elizaOS/eliza#16374).

MIT licensed, actively maintained (last push 2026-07-24).

### Related ecosystem presence

The protocol itself is on DefiLlama as `wealthville` (protocol id 8032, adapter merged in DefiLlama/DefiLlama-Adapters#19469), so the Solana ecosystem association is already established elsewhere.

### Validation

`open-dev-data validate` passes locally (exit 0, 770 migrations / 7,661 ecosystems / 750,568 repos), and `export -e Solana` confirms the repository resolves into the Solana ecosystem.

Happy to adjust the ecosystem placement or split it differently if you'd prefer — and to withdraw it if a single-repo addition isn't what you want here.