### PR TITLE
Add Ludo Arena to Celo ecosystem

### DIFF
--- a/migrations/2026-07-28T120000_add_ludo_arena_to_celo
+++ b/migrations/2026-07-28T120000_add_ludo_arena_to_celo
@@ -1,0 +1,2 @@
+-- Add Ludo Arena (real-money blitz Ludo on Celo) to the Celo ecosystem
+repadd Celo https://github.com/BacBacta/Ludo-arena


### PR DESCRIPTION
Ludo Arena (https://www.ludoarena.xyz) is a real-money blitz Ludo game live on Celo mainnet — on-chain cUSD escrow staking, soulbound event passes, provably fair dice. Contracts: escrow 0xabdfea03be58d3276b13b40885311d84259d7f4d, RacePass 0x3ca68b8a7e2c429dec33a34e0589173dfb305be4 (850+ transactions). Actively developed: 25+ merged PRs in July 2026.