### PR TITLE
Add algocast to Algorand ecosystem

### DIFF
--- a/migrations/2026-07-31T220500_add_algocast
+++ b/migrations/2026-07-31T220500_add_algocast
@@ -1,0 +1,1 @@
+repadd Algorand https://github.com/mitre88/algocast #developer-tool


### PR DESCRIPTION
Adds [algocast](https://github.com/mitre88/algocast), an MIT-licensed open-source CLI that decodes Algorand `logic eval error ... pc=NNN` failures into the exact TEAL source line — for any app, on any network, without an appspec.

Tagged `#developer-tool` per the tagging convention.