### PR TITLE
Add AtlasYield

### DIFF
--- a/migrations/2026-08-01T120000_add_atlasyield
+++ b/migrations/2026-08-01T120000_add_atlasyield
@@ -1,0 +1,3 @@
+-- Add AtlasYield -- independent rating and allocation layer for on-chain yield
+ecoadd AtlasYield
+repadd AtlasYield https://github.com/gveshk/atlasyield-score-history


### PR DESCRIPTION
Adds AtlasYield — an independent rating and allocation layer for on-chain yield (atlasyield.club). Scores every DeFi vault 0-100 across 16 factors / 4 pillars (yield quality, safety, liquidity, sustainability), 584 vaults daily across 8 protocols and 5 chains. Repo linked is the public, daily-committed score-history data repo (github.com/gveshk/atlasyield-score-history) — the main application repo is currently private.