### PR TITLE
Add eucompliance-tools to x402 and Base

### DIFF
--- a/migrations/2026-08-04T120000_add_eucompliance_tools
+++ b/migrations/2026-08-04T120000_add_eucompliance_tools
@@ -1,0 +1,2 @@
+repadd x402 https://github.com/PatrickPi1312/eucompliance-tools
+repadd Base https://github.com/PatrickPi1312/eucompliance-tools


### PR DESCRIPTION
Adds `PatrickPi1312/eucompliance-tools` to the **x402** ecosystem (dual-listed under **Base**).

It is a machine-payable API + MCP server that implements the x402 protocol directly: it returns real `HTTP 402 Payment Required`, settles per call in **USDC on Base**, serves `/.well-known/x402`, and ships on-chain preflight tools (tx simulation / ERC-20 allowance on Base) plus an ERC-8004 agent registration. This puts it in the same class as existing x402 entries (e.g. `dabit3/x402-starter-kit`, `Merit-Systems/x402scan`, `coinbase/x402`). Dual-listing under Base follows existing precedent for x402 projects that settle on Base (e.g. `vercel-labs/x402-ai-starter`).