### PR TITLE
Add Katana ecosystem

### DIFF
--- a/migrations/2026-08-05T221000_add_katana_ecosystem
+++ b/migrations/2026-08-05T221000_add_katana_ecosystem
@@ -1,0 +1,16 @@
+-- Add Katana, a DeFi-focused Ethereum Layer 2 incubated by Polygon Labs and GSR (katana.network)
+-- Mainnet live since June 2025, KAT token. Repos are original (non-fork) from the katana-network org.
+ecoadd Katana
+ecocon "EVM Compatible Layer 2s" Katana
+repadd Katana https://github.com/katana-network/specialk #developer-tool
+repadd Katana https://github.com/katana-network/kat-token
+repadd Katana https://github.com/katana-network/katana-docs #documentation
+repadd Katana https://github.com/katana-network/tokenlist
+repadd Katana https://github.com/katana-network/network-configs
+repadd Katana https://github.com/katana-network/node-snapshotter
+repadd Katana https://github.com/katana-network/op-forced-tx-script
+repadd Katana https://github.com/katana-network/lz-ops-demo
+repadd Katana https://github.com/katana-network/lz-kat-upgradeable
+repadd Katana https://github.com/katana-network/katana-ai
+repadd Katana https://github.com/katana-network/awesome-katana #community
+repadd Katana https://github.com/katana-network/status


### PR DESCRIPTION
Adds **Katana** (katana.network) — the DeFi-focused Ethereum L2 incubated by Polygon Labs and GSR, mainnet live since June 2025 (KAT token) — currently absent from the taxonomy.

- Org: [katana-network](https://github.com/katana-network) — active through this week
- Migration adds the ecosystem under "EVM Compatible Layer 2s" plus 12 original (non-fork) repos; forks (DefiLlama-Adapters, sushi subgraph, governance) excluded

Validated locally with `./run.sh validate` (passes clean).