### PR TITLE
Add Lighter ecosystem

### DIFF
--- a/migrations/2026-08-05T222000_add_lighter_ecosystem
+++ b/migrations/2026-08-05T222000_add_lighter_ecosystem
@@ -1,0 +1,12 @@
+-- Add Lighter, a zk-rollup perpetuals exchange settling on Ethereum (lighter.xyz)
+-- The elliottech org's earlier lighter v1/v2 repos are already attributed under Arbitrum/Ethereum;
+-- this adds the current zk-rollup stack, which was missing entirely.
+ecoadd Lighter
+ecocon Ethereum Lighter
+repadd Lighter https://github.com/elliottech/lighter-go #developer-tool
+repadd Lighter https://github.com/elliottech/lighter-python #developer-tool
+repadd Lighter https://github.com/elliottech/lighter-prover #protocol
+repadd Lighter https://github.com/elliottech/p3-lighter-circuits #zk-circuit
+repadd Lighter https://github.com/elliottech/lighter-agent-kit #developer-tool
+repadd Lighter https://github.com/elliottech/poseidon_crypto
+repadd Lighter https://github.com/elliottech/lighter-contracts


### PR DESCRIPTION
Adds **Lighter** (lighter.xyz) — the zk-rollup perpetuals exchange settling on Ethereum, consistently one of the highest-volume perp DEXs — missing as an ecosystem.

The taxonomy currently only tracks elliottech's legacy lighter v1/v2 repos (under Arbitrum/Ethereum). The entire current zk-rollup stack was untracked:

- [lighter-python](https://github.com/elliottech/lighter-python) (322 stars), [lighter-go](https://github.com/elliottech/lighter-go) (87 stars, pushed today), [lighter-prover](https://github.com/elliottech/lighter-prover) (63 stars), circuits, agent kit
- Migration adds the ecosystem under Ethereum plus 7 original (non-fork) repos

Validated locally with `./run.sh validate` (passes clean).