### PR TITLE
Add Sieve to Base, Optimism, and Worldcoin ecosystems

### DIFF
--- a/migrations/2026-08-21T154353_add_sieve_opstack_ecosystems
+++ b/migrations/2026-08-21T154353_add_sieve_opstack_ecosystems
@@ -1,0 +1,7 @@
+-- Add Sieve (Rust P2P Ethereum event indexer) to the OP-Stack ecosystems it now supports.
+-- Already present under Ethereum (migrations/2026-04-08T165859_mutations); not re-added here.
+repadd Base https://github.com/slvDev/sieve #developer-tool #indexer #rust
+repadd Optimism https://github.com/slvDev/sieve #developer-tool #indexer #rust
+repadd Worldcoin https://github.com/slvDev/sieve #developer-tool #indexer #rust
+repadd "Ethereum Virtual Machine Stack" https://github.com/slvDev/sieve #developer-tool #indexer #rust
+repadd "Multichain Infrastructure" https://github.com/slvDev/sieve #developer-tool #indexer #rust


### PR DESCRIPTION
Adds Sieve (github.com/slvDev/sieve), an open-source Rust Ethereum and OP-Stack event indexer that syncs directly over devp2p with no RPC provider, to the Base, Optimism, and Worldcoin ecosystems plus the EVM Stack and Multichain Infrastructure meta-ecosystems. Already listed under Ethereum; validated with `uvx open-dev-data validate`.